### PR TITLE
add ability to override regex matcher for a particular file extension

### DIFF
--- a/src/utils/diff/parsers/common.ts
+++ b/src/utils/diff/parsers/common.ts
@@ -7,7 +7,7 @@ export abstract class BaseParser {
     abstract variableMethodPattern: RegExp
     abstract variableNameCapturePattern: RegExp
 
-    constructor(protected options: ParseOptions) {
+    constructor(extension: string, protected options: ParseOptions) {
         this.clientNames = options.clientNames ?? ['dvcClient']
     }
 

--- a/src/utils/diff/parsers/custom.ts
+++ b/src/utils/diff/parsers/custom.ts
@@ -1,0 +1,28 @@
+import { BaseParser } from './common'
+import { ParseOptions } from './types'
+
+export class CustomParser extends BaseParser {
+    identity = 'custom'
+    variableMethodPattern = new RegExp('')
+    variableNameCapturePattern = new RegExp('')
+    customPattern: string
+
+    constructor(extension: string, options: ParseOptions) {
+        super(extension, options)
+
+        if (!options.matchPatterns || !(extension in options.matchPatterns)) {
+            throw new Error(`No match pattern for ${extension}`)
+        }
+
+        this.customPattern = options.matchPatterns[extension]
+    }
+
+    override buildRegexPattern(): RegExp {
+        return new RegExp(this.customPattern)
+    }
+
+    match(content: string): string | null {
+        const match = this.buildRegexPattern().exec(content)
+        return match ? match[1] : null
+    }
+}

--- a/src/utils/diff/parsers/types.ts
+++ b/src/utils/diff/parsers/types.ts
@@ -6,5 +6,6 @@ export type VariableMatch = {
 }
 
 export type ParseOptions = {
-    clientNames?: string[]
+    clientNames?: string[],
+    matchPatterns?: Record<string, string>
 }

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -25,11 +25,45 @@ DevCycle Variable Changes:
 	   Location: test/utils/diff/sampleDiff.js:L1
 `
 
+const customExpected = `
+DevCycle Variable Changes:
+
+✅ 5 Variables Added
+❌ 1 Variable Removed
+
+✅ Added
+
+	1. simple-case
+	   Locations:
+	    - test/utils/diff/sampleDiff.js:L1
+	    - test/utils/diff/sampleDiff.js:L2
+	2. single-quotes
+	   Location: test/utils/diff/sampleDiff.js:L4
+	3. single-comment
+	   Location: test/utils/diff/sampleDiff.js:L16
+	4. multi-line-comment
+	   Location: test/utils/diff/sampleDiff.js:L19
+	5. func-proxy
+	   Location: test/utils/diff/sampleDiff.js:L6
+
+❌ Removed
+
+	1. simple-case
+	   Location: test/utils/diff/sampleDiff.js:L1
+`
+
 describe('diff', () => {
     test
         .stdout()
         .command(['diff', '--file', './test/utils/diff/samples/nodeSampleDiff'])
         .it('runs against a test file', (ctx) => {
             expect(ctx.stdout).to.equal(expected)
+        })
+    test
+        .stdout()
+        .command(['diff', '--file',
+            './test/utils/diff/samples/nodeSampleDiff', '--match-pattern', 'js=checkVariable\\(\\w*,\\s*"([^"\']*)"'])
+        .it('runs against a test file with a custom matcher', (ctx) => {
+            expect(ctx.stdout).to.equal(customExpected)
         })
 })

--- a/test/utils/diff/nodejs.test.ts
+++ b/test/utils/diff/nodejs.test.ts
@@ -77,4 +77,19 @@ describe('nodejs', () => {
                 }]
         })
     })
+
+    it('identifies the correct variables using a custom pattern', () => {
+        const parsedDiff = executeFileDiff(path.join(__dirname, './samples/nodeSampleDiff'))
+        const results = parseFiles(parsedDiff, { matchPatterns: { js: 'checkVariable\\(\\w*,\\s*"([^"\']*)"' } })
+        expect(results).to.deep.equal({
+            nodejs: nodeSimpleMatchResult,
+            custom: [
+                {
+                    'fileName': 'test/utils/diff/sampleDiff.js',
+                    'line': 6,
+                    'mode': 'add',
+                    'name': 'func-proxy'
+                }]
+        })
+    })
 })


### PR DESCRIPTION
add `--match-pattern` flag to add _additional_ regex pattern to match on for a given file extension:
`dvc diff --match-pattern js="\\.variable"`