### PR TITLE
add ability to load config from a yaml file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,16 @@
   "dependencies": {
     "@oclif/core": "^1",
     "@oclif/plugin-help": "^5",
+    "@types/js-yaml": "^4.0.5",
+    "@types/validator": "^13.7.1",
     "axios": "^0.24.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.13.2",
     "cli-ux": "^6.0.8",
+    "js-yaml": "^4.1.0",
     "node-emoji": "^1.11.0",
-    "parse-diff": "^0.9.0"
+    "parse-diff": "^0.9.0",
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@oclif/test": "^2",

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -1,18 +1,51 @@
+import 'reflect-metadata'
+
 import { Command, Flags } from '@oclif/core'
-import { authenticate } from '../api/authenticate'
+import fs from 'fs'
+import jsYaml from 'js-yaml'
+import { ConfigFromFile } from './types'
+import { plainToClass } from 'class-transformer'
+import { validateSync } from 'class-validator'
 
 export default abstract class Base extends Command {
     static hidden = true
     static flags = {
-        client_id: Flags.string({ char: 'c', description: 'DevCycle Client Id', required: true }),
-        client_secret: Flags.string({ char: 's', description: 'DevCycle Client Secret', required: true }),
-        project: Flags.string({ char: 'p', description: 'Project identifier (id or key)', required: true }),
+        'config-path': Flags.string({
+            description: 'Override the default location to look for a config.yml file',
+            default: '.devcycle/config.yml'
+        })
     }
 
     token: string | null = null
 
+    configFromFile: ConfigFromFile | null
+
+    loadConfig(path: string): ConfigFromFile | null {
+        if (!fs.existsSync(path)) {
+            return null
+        }
+
+        const config = jsYaml.load(fs.readFileSync(path, 'utf8'))
+
+        const configParsed = plainToClass(ConfigFromFile, config, { excludeExtraneousValues: false })
+
+        const errors = validateSync(configParsed)
+
+        if (errors.length) {
+            let error = errors[0]
+            while (error.children?.length) {
+                error = error.children[0]
+            }
+
+            this.error(`Config file failed validation at property "${error.property}": ` +
+                `${Object.values(error.constraints ?? {})[0]}`)
+        }
+
+        return configParsed
+    }
+
     async init() {
         const { flags } = await this.parse(this.constructor as typeof Base)
-        this.token = await authenticate(flags.client_id, flags.client_secret)
+        this.configFromFile = this.loadConfig(flags['config-path'])
     }
 }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,53 @@
+import { Type } from 'class-transformer'
+import {
+    IsArray,
+    IsObject,
+    IsOptional,
+    IsString,
+    registerDecorator,
+    ValidateNested,
+    ValidationOptions
+} from 'class-validator'
+
+function ValidateMatchPatterns(validationOptions?: ValidationOptions) {
+    return function(object: any, propertyName: string) {
+        registerDecorator({
+            name: 'ValidateMatchPatterns',
+            target: object.constructor,
+            propertyName,
+            options: {
+                message: `${propertyName} must be an object mapping file extensions to an array of Regex patterns`,
+                ...validationOptions
+            },
+            validator: {
+                validate(value: Record<string, unknown>) {
+                    for (const key in value) {
+                        if (!Array.isArray(value[key])) {
+                            return false
+                        }
+                    }
+
+                    return true
+                },
+            },
+        })
+    }
+}
+
+class CodeInsights {
+    @IsString({ each: true })
+    @IsOptional()
+    clientNames?: string[]
+
+    @IsOptional()
+    @IsObject()
+    @ValidateMatchPatterns()
+    matchPatterns?: Record<string, string[]>
+}
+
+export class ConfigFromFile {
+    @Type(() => CodeInsights)
+    @IsOptional()
+    @ValidateNested()
+    codeInsights?: CodeInsights
+}

--- a/src/utils/diff/parse.ts
+++ b/src/utils/diff/parse.ts
@@ -31,6 +31,7 @@ export const parseFiles = (files: parse.File[], options: ParseOptions = {}): Rec
     for (const file of files) {
         const fileExtension = file.to?.split('.').pop() ?? ''
         const Parsers = ALL_PARSERS[fileExtension] || []
+
         for (const Parser of Parsers) {
             const parser = new Parser(fileExtension, options)
             const result = parser.parse(file)

--- a/src/utils/diff/parsers/common.ts
+++ b/src/utils/diff/parsers/common.ts
@@ -8,7 +8,7 @@ export abstract class BaseParser {
     abstract variableNameCapturePattern: RegExp
 
     constructor(extension: string, protected options: ParseOptions) {
-        this.clientNames = options.clientNames ?? ['dvcClient']
+        this.clientNames = [...(options.clientNames || []), 'dvcClient']
     }
 
     buildRegexPattern() {

--- a/src/utils/diff/parsers/custom.ts
+++ b/src/utils/diff/parsers/custom.ts
@@ -5,7 +5,7 @@ export class CustomParser extends BaseParser {
     identity = 'custom'
     variableMethodPattern = new RegExp('')
     variableNameCapturePattern = new RegExp('')
-    customPattern: string
+    customPatterns: string[]
 
     constructor(extension: string, options: ParseOptions) {
         super(extension, options)
@@ -14,15 +14,15 @@ export class CustomParser extends BaseParser {
             throw new Error(`No match pattern for ${extension}`)
         }
 
-        this.customPattern = options.matchPatterns[extension]
-    }
-
-    override buildRegexPattern(): RegExp {
-        return new RegExp(this.customPattern)
+        this.customPatterns = options.matchPatterns[extension]
     }
 
     match(content: string): string | null {
-        const match = this.buildRegexPattern().exec(content)
-        return match ? match[1] : null
+        for (const pattern of this.customPatterns) {
+            const match = (new RegExp(pattern)).exec(content)
+            if (match) return match[1]
+        }
+
+        return null
     }
 }

--- a/src/utils/diff/parsers/types.ts
+++ b/src/utils/diff/parsers/types.ts
@@ -7,5 +7,5 @@ export type VariableMatch = {
 
 export type ParseOptions = {
     clientNames?: string[],
-    matchPatterns?: Record<string, string>
+    matchPatterns?: Record<string, string[]>
 }

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -59,6 +59,7 @@ describe('diff', () => {
         .it('runs against a test file', (ctx) => {
             expect(ctx.stdout).to.equal(expected)
         })
+
     test
         .stdout()
         .command(['diff', '--file',
@@ -66,4 +67,13 @@ describe('diff', () => {
         .it('runs against a test file with a custom matcher', (ctx) => {
             expect(ctx.stdout).to.equal(customExpected)
         })
+
+    test
+        .stdout()
+        .command(['diff', '--file',
+            './test/utils/diff/samples/nodeSampleDiff', '--config-path', './test/commands/fixtures/testConfig.yml'])
+        .it('runs against a test file with a custom matcher specified in a config file',
+            (ctx) => {
+                expect(ctx.stdout).to.equal(customExpected)
+            })
 })

--- a/test/commands/fixtures/testConfig.yml
+++ b/test/commands/fixtures/testConfig.yml
@@ -1,0 +1,4 @@
+codeInsights:
+  matchPatterns:
+    js:
+      - checkVariable\(\w*,\s*"([^"']*)"

--- a/test/utils/diff/nodejs.test.ts
+++ b/test/utils/diff/nodejs.test.ts
@@ -54,12 +54,14 @@ describe('nodejs', () => {
         const parsedDiff = executeFileDiff(path.join(__dirname, './samples/nodeSampleDiff'))
         const results = parseFiles(parsedDiff, { clientNames: ['dvc'] })
         expect(results).to.deep.equal({
-            nodejs: [{
-                'fileName': 'test/utils/diff/sampleDiff.js',
-                'line': 23,
-                'mode': 'add',
-                'name': 'renamed-case'
-            }]
+            nodejs: [
+                ...nodeSimpleMatchResult,
+                {
+                    'fileName': 'test/utils/diff/sampleDiff.js',
+                    'line': 23,
+                    'mode': 'add',
+                    'name': 'renamed-case'
+                }]
         })
     })
 
@@ -80,7 +82,7 @@ describe('nodejs', () => {
 
     it('identifies the correct variables using a custom pattern', () => {
         const parsedDiff = executeFileDiff(path.join(__dirname, './samples/nodeSampleDiff'))
-        const results = parseFiles(parsedDiff, { matchPatterns: { js: 'checkVariable\\(\\w*,\\s*"([^"\']*)"' } })
+        const results = parseFiles(parsedDiff, { matchPatterns: { js: ['checkVariable\\(\\w*,\\s*"([^"\']*)"'] } })
         expect(results).to.deep.equal({
             nodejs: nodeSimpleMatchResult,
             custom: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "strictPropertyInitialization": false,
+    "experimentalDecorators": true,
     "target": "es2019"
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,6 +444,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/js-yaml@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/json-schema@^7.0.7":
   version "7.0.9"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz"
@@ -485,6 +490,11 @@
   integrity sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==
   dependencies:
     "@sinonjs/fake-timers" "^7.1.0"
+
+"@types/validator@^13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.1.tgz#cdab1b4779f6b1718a08de89d92d2603b71950cb"
+  integrity sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q==
 
 "@typescript-eslint/eslint-plugin@^4.31.2":
   version "4.33.0"
@@ -1064,6 +1074,11 @@ ci-info@^3.2.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz"
   integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
@@ -1073,6 +1088,14 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+class-validator@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
+  integrity sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==
+  dependencies:
+    libphonenumber-js "^1.9.43"
+    validator "^13.7.0"
 
 clean-regexp@^1.0.0:
   version "1.0.0"
@@ -3017,7 +3040,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -3133,6 +3156,11 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+libphonenumber-js@^1.9.43:
+  version "1.9.44"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz#d036364fe4c1e27205d1d283c7bf8fc25625200b"
+  integrity sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -4257,6 +4285,11 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz"
@@ -5145,6 +5178,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vinyl-file@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
-adds support for loading clientNames and matchPatterns from a devcycle configuration file
-also adjusts match patterns so you can have more than one pattern per file extension
-change clientNames override behaviour to be "additive" so that `dvcClient` is still checked