### PR TITLE
Ignore any lines that start with a comment character

### DIFF
--- a/src/utils/diff/parsers/android/index.ts
+++ b/src/utils/diff/parsers/android/index.ts
@@ -4,6 +4,7 @@ export class AndroidParser extends BaseParser {
     identity = 'android'
     variableMethodPattern = /\.variable\(\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/**', '*', '<!--']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/csharp/index.ts
+++ b/src/utils/diff/parsers/csharp/index.ts
@@ -4,6 +4,7 @@ export class CsharpParser extends BaseParser {
     identity = 'csharp'
     variableMethodPattern = /\.VariableAsync\([\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/golang/index.ts
+++ b/src/utils/diff/parsers/golang/index.ts
@@ -4,6 +4,7 @@ export class GolangParser extends BaseParser {
     identity = 'golang'
     variableMethodPattern = /DevcycleApi\.Variable\([\s\w]*,[\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/ios/index.ts
+++ b/src/utils/diff/parsers/ios/index.ts
@@ -4,6 +4,7 @@ export class IosParser extends BaseParser {
     identity = 'ios'
     variableMethodPattern = /\.variable\(\s*key:\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['///', '/**']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/java/index.ts
+++ b/src/utils/diff/parsers/java/index.ts
@@ -4,6 +4,7 @@ export class JavaParser extends BaseParser {
     identity = 'java'
     variableMethodPattern = /\.variable\([\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['/**', '*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/javascript/index.ts
+++ b/src/utils/diff/parsers/javascript/index.ts
@@ -4,6 +4,7 @@ export class JavascriptParser extends BaseParser {
     identity = 'javascript'
     variableMethodPattern = /\.variable\(\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/nodejs/index.ts
+++ b/src/utils/diff/parsers/nodejs/index.ts
@@ -4,6 +4,7 @@ export class NodeParser extends BaseParser {
     identity = 'nodejs'
     variableMethodPattern = /\.variable\([\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/php/index.ts
+++ b/src/utils/diff/parsers/php/index.ts
@@ -4,6 +4,7 @@ export class PhpParser extends BaseParser {
     identity = 'php'
     variableMethodPattern = /->variable\([\s\w$]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '#', '/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/python/index.ts
+++ b/src/utils/diff/parsers/python/index.ts
@@ -4,6 +4,7 @@ export class PythonParser extends BaseParser {
     identity = 'python'
     variableMethodPattern = /\.variable\([\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['#', '"""']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/src/utils/diff/parsers/react/index.ts
+++ b/src/utils/diff/parsers/react/index.ts
@@ -6,6 +6,7 @@ export class ReactParser extends BaseParser {
     identity = 'react'
     variableMethodPattern = /\.variable\(\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['//', '/*', '{/*']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content) ?? findVariableHookRegex.exec(content)

--- a/src/utils/diff/parsers/ruby/index.ts
+++ b/src/utils/diff/parsers/ruby/index.ts
@@ -4,6 +4,7 @@ export class RubyParser extends BaseParser {
     identity = 'ruby'
     variableMethodPattern = /\.variable\([\s\w]*,\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
+    commentCharacters = ['#']
 
     match(content: string): RegExpExecArray | null {
         return this.buildRegexPattern().exec(content)

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -3,6 +3,31 @@ import { expect, test } from '@oclif/test'
 const expected = `
 DevCycle Variable Changes:
 
+✅ 4 Variables Added
+❌ 1 Variable Removed
+
+✅ Added
+
+	1. simple-case
+	   Locations:
+	    - test/utils/diff/sampleDiff.js:L1
+	    - test/utils/diff/sampleDiff.js:L2
+	2. single-quotes
+	   Location: test/utils/diff/sampleDiff.js:L4
+	3. multi-line
+	   Location: test/utils/diff/sampleDiff.js:L10
+	4. multi-line-comment
+	   Location: test/utils/diff/sampleDiff.js:L19
+
+❌ Removed
+
+	1. simple-case
+	   Location: test/utils/diff/sampleDiff.js:L1
+`
+
+const customExpected = `
+DevCycle Variable Changes:
+
 ✅ 5 Variables Added
 ❌ 1 Variable Removed
 
@@ -16,38 +41,9 @@ DevCycle Variable Changes:
 	   Location: test/utils/diff/sampleDiff.js:L4
 	3. multi-line
 	   Location: test/utils/diff/sampleDiff.js:L10
-	4. single-comment
-	   Location: test/utils/diff/sampleDiff.js:L16
-	5. multi-line-comment
+	4. multi-line-comment
 	   Location: test/utils/diff/sampleDiff.js:L19
-
-❌ Removed
-
-	1. simple-case
-	   Location: test/utils/diff/sampleDiff.js:L1
-`
-
-const customExpected = `
-DevCycle Variable Changes:
-
-✅ 6 Variables Added
-❌ 1 Variable Removed
-
-✅ Added
-
-	1. simple-case
-	   Locations:
-	    - test/utils/diff/sampleDiff.js:L1
-	    - test/utils/diff/sampleDiff.js:L2
-	2. single-quotes
-	   Location: test/utils/diff/sampleDiff.js:L4
-	3. multi-line
-	   Location: test/utils/diff/sampleDiff.js:L10
-	4. single-comment
-	   Location: test/utils/diff/sampleDiff.js:L16
-	5. multi-line-comment
-	   Location: test/utils/diff/sampleDiff.js:L19
-	6. func-proxy
+	5. func-proxy
 	   Location: test/utils/diff/sampleDiff.js:L6
 
 ❌ Removed

--- a/test/utils/diff/parse.test.ts
+++ b/test/utils/diff/parse.test.ts
@@ -81,4 +81,63 @@ describe('parse', () => {
             })
         })
     })
+
+    describe('single comment', () => {
+        it('identifies no change when addition is commented', () => {
+            const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/add-comment'))
+            const results = parseFiles(parsedDiff)
+    
+            expect(results).to.deep.equal({})
+        })
+
+        it('identifies addition when line is uncommented', () => {
+            const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/uncomment'))
+            const results = parseFiles(parsedDiff)
+    
+            expect(results).to.deep.equal({
+                nodejs: [{
+                    'fileName': 'services/api/src/organizations/organizations.controller.ts',
+                    'line': 177,
+                    'mode': 'add',
+                    'name': 'variable-key'
+                }]
+            })
+        })
+
+        it('identifies deletion when line is commented', () => {
+            const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/comment'))
+            const results = parseFiles(parsedDiff)
+    
+            expect(results).to.deep.equal({
+                nodejs: [{
+                    'fileName': 'services/api/src/organizations/organizations.controller.ts',
+                    'line': 177,
+                    'mode': 'remove',
+                    'name': 'variable-key'
+                }]
+            })
+        })
+
+        it('identifies change when parameter is commented', () => {
+            const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/param-comment'))
+            const results = parseFiles(parsedDiff)
+    
+            expect(results).to.deep.equal({
+                nodejs: [
+                    {
+                        'fileName': 'services/api/src/organizations/organizations.controller.ts',
+                        'line': 177,
+                        'mode': 'add',
+                        'name': 'new-variable'
+                    },
+                    {
+                        'fileName': 'services/api/src/organizations/organizations.controller.ts',
+                        'line': 177,
+                        'mode': 'remove',
+                        'name': 'variable-key'
+                    }
+                ]
+            })
+        })
+    })
 })

--- a/test/utils/diff/parsers/nodejs.test.ts
+++ b/test/utils/diff/parsers/nodejs.test.ts
@@ -31,12 +31,6 @@ describe('nodejs', () => {
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
-            'line': 16,
-            'mode': 'add',
-            'name': 'single-comment'
-        },
-        {
-            'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 19,
             'mode': 'add',
             'name': 'multi-line-comment'

--- a/test/utils/diff/samples/comments/add-comment
+++ b/test/utils/diff/samples/comments/add-comment
@@ -1,0 +1,32 @@
+diff --git a/services/api/src/organizations/organizations.controller.ts b/services/api/src/organizations/organizations.controller.ts
+index 429092e6..2698d364 100644
+--- a/services/api/src/organizations/organizations.controller.ts
++++ b/services/api/src/organizations/organizations.controller.ts
+@@ -26,6 +26,7 @@ import { UpdateOrganizationDTO } from './dto/update-organization.dto'
+ import { NoPersonalOrganizationGuard } from '../utils/guards'
+ import { RequireScopes, PermissionsGuard } from 'lib/nest/permissions-guard/src'
+ import { DeleteOrganizationsDTO } from './dto/delete-organization.dto'
++import { DVCClient } from 'sdk/nodejs-server-sdk/types'
+ @Controller({
+     path: '/organizations',
+     version: '1'
+@@ -36,7 +37,8 @@ export class OrganizationsController {
+     constructor(
+         private organizationsService: OrganizationsService,
+         private usersService: UsersService,
+-        private projectsService: ProjectsService
++        private projectsService: ProjectsService,
++        private dvcClient: DVCClient
+     ) { }
+ 
+     // Operations on the whole organizations collection
+@@ -171,6 +173,9 @@ export class OrganizationsController {
+         @User() user: RequestUser,
+         @Body() upgradeOrganizationDto: UpgradeOrganizationDTO
+     ) {
++        const dvcUser = { user_id: 'id' }
++        // this.dvcClient.variable(dvcUser, 'variable-key', true)
++        
+         const organization = await this.organizationsService.create(user.sub, upgradeOrganizationDto)
+         await this.projectsService.migrate(user.sub, organization.id)
+         return organization

--- a/test/utils/diff/samples/comments/comment
+++ b/test/utils/diff/samples/comments/comment
@@ -1,0 +1,13 @@
+diff --git a/services/api/src/organizations/organizations.controller.ts b/services/api/src/organizations/organizations.controller.ts
+index 2698d364..e009774e 100644
+--- a/services/api/src/organizations/organizations.controller.ts
++++ b/services/api/src/organizations/organizations.controller.ts
+@@ -174,7 +174,7 @@ export class OrganizationsController {
+         @Body() upgradeOrganizationDto: UpgradeOrganizationDTO
+     ) {
+         const dvcUser = { user_id: 'id' }
+-        this.dvcClient.variable(dvcUser, 'variable-key', true)
++        // this.dvcClient.variable(dvcUser, 'variable-key', true)
+         
+         const organization = await this.organizationsService.create(user.sub, upgradeOrganizationDto)
+         await this.projectsService.migrate(user.sub, organization.id)

--- a/test/utils/diff/samples/comments/param-comment
+++ b/test/utils/diff/samples/comments/param-comment
@@ -1,0 +1,14 @@
+diff --git a/services/api/src/organizations/organizations.controller.ts b/services/api/src/organizations/organizations.controller.ts
+index ed310f17..c917e8e3 100644
+--- a/services/api/src/organizations/organizations.controller.ts
++++ b/services/api/src/organizations/organizations.controller.ts
+@@ -176,7 +176,8 @@ export class OrganizationsController {
+         const dvcUser = { user_id: 'id' }
+         this.dvcClient.variable(
+             dvcUser,
+-            'variable-key',
++            'new-variable',
++            // 'variable-key',
+             true
+         )
+         

--- a/test/utils/diff/samples/comments/uncomment
+++ b/test/utils/diff/samples/comments/uncomment
@@ -1,0 +1,13 @@
+diff --git a/services/api/src/organizations/organizations.controller.ts b/services/api/src/organizations/organizations.controller.ts
+index 2698d364..e009774e 100644
+--- a/services/api/src/organizations/organizations.controller.ts
++++ b/services/api/src/organizations/organizations.controller.ts
+@@ -174,7 +174,7 @@ export class OrganizationsController {
+         @Body() upgradeOrganizationDto: UpgradeOrganizationDTO
+     ) {
+         const dvcUser = { user_id: 'id' }
+-        // this.dvcClient.variable(dvcUser, 'variable-key', true)
++        this.dvcClient.variable(dvcUser, 'variable-key', true)
+         
+         const organization = await this.organizationsService.create(user.sub, upgradeOrganizationDto)
+         await this.projectsService.migrate(user.sub, organization.id)


### PR DESCRIPTION
If a change's content starts with a comment character, ignore it.

This should allow us to correctly match around single-line comments. In some cases multi-line comments may be handled correctly, but they'll need some extra consideration.