### PR TITLE
Update react parser

### DIFF
--- a/src/utils/diff/parsers/common.ts
+++ b/src/utils/diff/parsers/common.ts
@@ -58,6 +58,7 @@ class ParsedChange {
 
 export abstract class BaseParser {
     abstract identity: string
+    matchClientName = true
     clientNames: string[]
     abstract variableMethodPattern: RegExp
     variableMethodKeywordPattern : RegExp | null = null
@@ -73,9 +74,10 @@ export abstract class BaseParser {
         const variableRegex = this.variableMethodKeywordPattern ?
             `(?:${this.variableMethodKeywordPattern.source}|${this.variableMethodPattern.source})` :
             this.variableMethodPattern.source
+        const clientNamePattern = this.matchClientName ? new RegExp(`(?:${this.clientNames.join('|')})`).source : ''
 
         return new RegExp(
-            new RegExp(`(?:${this.clientNames.join('|')})`).source
+            clientNamePattern
             + new RegExp(variableRegex).source
             + this.variableNameCapturePattern.source
             + this.defaultValueCapturePattern.source

--- a/src/utils/diff/parsers/react/index.ts
+++ b/src/utils/diff/parsers/react/index.ts
@@ -1,15 +1,14 @@
 import { BaseParser } from '../common'
 
-const findVariableHookRegex = /useVariable\(\s*["']([^"']*)["']/
-
 export class ReactParser extends BaseParser {
     identity = 'react'
-    variableMethodPattern = /\??\.variable\(\s*/
+    matchClientName = false
+    variableMethodPattern = /useVariable\(\s*/
     variableNameCapturePattern = /["']([^"']*)["']/
     defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
     commentCharacters = ['//', '/*', '{/*']
 
     match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content) ?? findVariableHookRegex.exec(content)
+        return this.buildRegexPattern().exec(content)
     }
 }


### PR DESCRIPTION
- Don't use the client for react parser
- Since the react parser runs with the js parser, we don't need to check for `.variable` usage as well