### PR TITLE
Handle matching on any valid user object

### DIFF
--- a/src/utils/diff/parsers/android/index.ts
+++ b/src/utils/diff/parsers/android/index.ts
@@ -1,14 +1,22 @@
 import { BaseParser } from '../common'
 
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class AndroidParser extends BaseParser {
     identity = 'android'
-    variableMethodPattern = /\??\.variable\(\s*/
-    variableMethodKeywordPattern = /\??\.variable\(\s*key\s*=\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '/**', '*', '<!--']
+    variableMethodPattern = /\??\.variable\(/
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
+    orderedParameterPatterns = [
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
+    namedParameterDelimiter = '='
+    namedParameterPatternMap = {
+        key: variableNameCapturePattern,
+        default: defaultValueCapturePattern
     }
+
+    commentCharacters = ['//', '/**', '*', '<!--']
 }

--- a/src/utils/diff/parsers/csharp/index.ts
+++ b/src/utils/diff/parsers/csharp/index.ts
@@ -1,14 +1,24 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:\w*|{[^})]*}|new[^)]*\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class CsharpParser extends BaseParser {
     identity = 'csharp'
-    variableMethodPattern = /\??\.VariableAsync\([\s\w]*,\s*/
-    variableMethodKeywordPattern = /\??\.VariableAsync\([\s\w:,]*key\s*:\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '/*']
+    variableMethodPattern = /\??\.VariableAsync\(/
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
+    orderedParameterPatterns = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
+    namedParameterPatternMap = {
+        user: userCapturePattern,
+        key: variableNameCapturePattern,
+        default: defaultValueCapturePattern
     }
+
+    commentCharacters = ['//', '/*']
 }

--- a/src/utils/diff/parsers/custom.ts
+++ b/src/utils/diff/parsers/custom.ts
@@ -4,8 +4,6 @@ import { ParseOptions } from './types'
 export class CustomParser extends BaseParser {
     identity = 'custom'
     variableMethodPattern = new RegExp('')
-    variableNameCapturePattern = new RegExp('')
-    defaultValueCapturePattern = new RegExp('')
     customPatterns: string[]
 
     constructor(extension: string, options: ParseOptions) {

--- a/src/utils/diff/parsers/golang/index.ts
+++ b/src/utils/diff/parsers/golang/index.ts
@@ -1,13 +1,20 @@
 import { BaseParser } from '../common'
 
+const authPattern = /\w*/
+const userCapturePattern = /(?:\w*|[\w\s.]*{[^})]*})/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class GolangParser extends BaseParser {
     identity = 'golang'
-    variableMethodPattern = /\.DevcycleApi\.Variable\([\s\w]*,[\s\w]*,\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
+    variableMethodPattern = /\.DevcycleApi\.Variable\(\s*/
+    orderedParameterPatterns = [
+        authPattern,
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
     commentCharacters = ['//', '/*']
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
 }

--- a/src/utils/diff/parsers/ios/index.ts
+++ b/src/utils/diff/parsers/ios/index.ts
@@ -1,13 +1,17 @@
 import { BaseParser } from '../common'
 
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class IosParser extends BaseParser {
     identity = 'ios'
-    variableMethodPattern = /\??\.variable\(\s*key:\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['///', '/**']
+    variableMethodPattern = /\??\.variable\(/
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
+    namedParameterDelimiter = ':'
+    namedParameterPatternMap = {
+        key: variableNameCapturePattern,
+        defaultValue: defaultValueCapturePattern
     }
+
+    commentCharacters = ['///', '/**']
 }

--- a/src/utils/diff/parsers/java/index.ts
+++ b/src/utils/diff/parsers/java/index.ts
@@ -1,13 +1,17 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:\w*|{[^})]*}|new[^)]*\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class JavaParser extends BaseParser {
     identity = 'java'
-    variableMethodPattern = /\.variable\([\s\w]*,\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['/**', '*']
+    variableMethodPattern = /\.variable\(\s*/
+    orderedParameterPatterns = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
+    commentCharacters = ['/**', '*']
 }

--- a/src/utils/diff/parsers/javascript/index.ts
+++ b/src/utils/diff/parsers/javascript/index.ts
@@ -1,13 +1,15 @@
 import { BaseParser } from '../common'
 
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class JavascriptParser extends BaseParser {
     identity = 'javascript'
     variableMethodPattern = /\??\.variable\(\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '/*']
+    orderedParameterPatterns = [
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
+    commentCharacters = ['//', '/*']
 }

--- a/src/utils/diff/parsers/nodejs/index.ts
+++ b/src/utils/diff/parsers/nodejs/index.ts
@@ -1,13 +1,18 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:\w*|{[^})]*}|new[^)]*\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class NodeParser extends BaseParser {
     identity = 'nodejs'
-    variableMethodPattern = /\??\.variable\([\s\w]*,\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '/*']
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
+    variableMethodPattern = /\??\.variable\(\s*/
+    orderedParameterPatterns: RegExp[] | null = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
+    commentCharacters = ['//', '/*']
 }

--- a/src/utils/diff/parsers/php/index.ts
+++ b/src/utils/diff/parsers/php/index.ts
@@ -1,14 +1,24 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:\$\w*|{[^})]*}|new[^)]*\)|array\([^)]*\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class PhpParser extends BaseParser {
     identity = 'php'
-    variableMethodPattern = /\??->variable\([\s\w$]*,\s*/
-    variableMethodKeywordPattern = /\??->variable\([\s\w$:,]*key\s*:\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '#', '/*']
+    variableMethodPattern = /\??->variable\(\s*/
+    orderedParameterPatterns = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
+    namedParameterDelimiter = ':'
+    namedParameterPatternMap = {
+        key: variableNameCapturePattern,
+        user: userCapturePattern,
+        defaultValue: defaultValueCapturePattern
     }
+
+    commentCharacters = ['//', '#', '/*']
 }

--- a/src/utils/diff/parsers/python/index.ts
+++ b/src/utils/diff/parsers/python/index.ts
@@ -1,14 +1,25 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:\w*|{[^})]*}|\w*\([^)]*\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class PythonParser extends BaseParser {
     identity = 'python'
-    variableMethodPattern = /\.variable\([\s\w]*,\s*/
-    variableMethodKeywordPattern = /\.variable\([\s\w=,]*key\s*=\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['#', '"""']
+    variableMethodPattern = /\.variable\(\s*/
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
+    orderedParameterPatterns = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
+    namedParameterDelimiter = '='
+    namedParameterPatternMap = {
+        key: variableNameCapturePattern,
+        user: userCapturePattern,
+        defaultValue: defaultValueCapturePattern
     }
+
+    commentCharacters = ['#', '"""']
 }

--- a/src/utils/diff/parsers/react/index.ts
+++ b/src/utils/diff/parsers/react/index.ts
@@ -1,14 +1,16 @@
 import { BaseParser } from '../common'
 
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class ReactParser extends BaseParser {
     identity = 'react'
     matchClientName = false
     variableMethodPattern = /useVariable\(\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['//', '/*', '{/*']
+    orderedParameterPatterns = [
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
+    commentCharacters = ['//', '/*', '{/*']
 }

--- a/src/utils/diff/parsers/ruby/index.ts
+++ b/src/utils/diff/parsers/ruby/index.ts
@@ -1,13 +1,17 @@
 import { BaseParser } from '../common'
 
+const userCapturePattern = /(?:[\s\w]*|{[^})]*}|[\w.:]*new\({[^)}]*}\))/
+const variableNameCapturePattern = /["']([^"']*)["']/
+const defaultValueCapturePattern = /(?:[^)]*)/
+
 export class RubyParser extends BaseParser {
     identity = 'ruby'
-    variableMethodPattern = /&?\.variable\([\s\w]*,\s*/
-    variableNameCapturePattern = /["']([^"']*)["']/
-    defaultValueCapturePattern = /\s*,\s*([^)]*)\)/
-    commentCharacters = ['#']
+    variableMethodPattern = /&?\.variable\(\s*/
+    orderedParameterPatterns = [
+        userCapturePattern,
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
 
-    match(content: string): RegExpExecArray | null {
-        return this.buildRegexPattern().exec(content)
-    }
+    commentCharacters = ['#']
 }

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -7,21 +7,23 @@ process.env = {}
 const expected = `
 DevCycle Variable Changes:
 
-✅  4 Variables Added
+✅  5 Variables Added
 ❌  1 Variable Removed
 
 ✅ Added
 
   1. simple-case
+	   Location: test/utils/diff/sampleDiff.js:L1
+  2. duplicate-case
 	   Locations:
-	    - test/utils/diff/sampleDiff.js:L1
 	    - test/utils/diff/sampleDiff.js:L2
-  2. single-quotes
-	   Location: test/utils/diff/sampleDiff.js:L4
-  3. multi-line
-	   Location: test/utils/diff/sampleDiff.js:L10
-  4. multi-line-comment
-	   Location: test/utils/diff/sampleDiff.js:L20
+	    - test/utils/diff/sampleDiff.js:L3
+  3. single-quotes
+	   Location: test/utils/diff/sampleDiff.js:L5
+  4. multi-line
+	   Location: test/utils/diff/sampleDiff.js:L11
+  5. multi-line-comment
+	   Location: test/utils/diff/sampleDiff.js:L21
 
 ❌ Removed
 
@@ -32,23 +34,25 @@ DevCycle Variable Changes:
 const customExpected = `
 DevCycle Variable Changes:
 
-✅  5 Variables Added
+✅  6 Variables Added
 ❌  1 Variable Removed
 
 ✅ Added
 
   1. simple-case
+	   Location: test/utils/diff/sampleDiff.js:L1
+  2. duplicate-case
 	   Locations:
-	    - test/utils/diff/sampleDiff.js:L1
 	    - test/utils/diff/sampleDiff.js:L2
-  2. single-quotes
-	   Location: test/utils/diff/sampleDiff.js:L4
-  3. multi-line
-	   Location: test/utils/diff/sampleDiff.js:L10
-  4. multi-line-comment
-	   Location: test/utils/diff/sampleDiff.js:L20
-  5. func-proxy
-	   Location: test/utils/diff/sampleDiff.js:L6
+	    - test/utils/diff/sampleDiff.js:L3
+  3. single-quotes
+	   Location: test/utils/diff/sampleDiff.js:L5
+  4. multi-line
+	   Location: test/utils/diff/sampleDiff.js:L11
+  5. multi-line-comment
+	   Location: test/utils/diff/sampleDiff.js:L21
+  6. func-proxy
+\t   Location: test/utils/diff/sampleDiff.js:L7
 
 ❌ Removed
 
@@ -59,21 +63,23 @@ DevCycle Variable Changes:
 const linkedExpected = `
 DevCycle Variable Changes:
 
-✅  4 Variables Added
+✅  5 Variables Added
 ❌  1 Variable Removed
 
 ✅ Added
 
   1. simple-case
+	   Location: [test/utils/diff/sampleDiff.js:L1](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R1)
+  2. duplicate-case
 	   Locations:
-	    - [test/utils/diff/sampleDiff.js:L1](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R1)
 	    - [test/utils/diff/sampleDiff.js:L2](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R2)
-  2. single-quotes
-	   Location: [test/utils/diff/sampleDiff.js:L4](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R4)
-  3. multi-line
-	   Location: [test/utils/diff/sampleDiff.js:L10](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R10)
-  4. multi-line-comment
-	   Location: [test/utils/diff/sampleDiff.js:L20](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R20)
+	    - [test/utils/diff/sampleDiff.js:L3](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R3)
+  3. single-quotes
+	   Location: [test/utils/diff/sampleDiff.js:L5](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R5)
+  4. multi-line
+	   Location: [test/utils/diff/sampleDiff.js:L11](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R11)
+  5. multi-line-comment
+	   Location: [test/utils/diff/sampleDiff.js:L21](https://example.com/files#diff-c197a837fe3ee51fcef381dc90df1cde5c759ad43f47c0cb72968af943205fa3R21)
 
 ❌ Removed
 
@@ -119,7 +125,7 @@ The following variables that do not exist in DevCycle were cleaned up:
 describe('diff', () => {
     test
         .stdout()
-        .command(['diff', '--file', './test/utils/diff/samples/nodejs', '--no-api'])
+        .command(['diff', '--file', './test/utils/diff/samples/e2e', '--no-api'])
         .it('runs against a test file', (ctx) => {
             expect(ctx.stdout).to.equal(expected)
         })
@@ -127,7 +133,7 @@ describe('diff', () => {
     test
         .stdout()
         .command(['diff', '--file',
-            './test/utils/diff/samples/nodejs',
+            './test/utils/diff/samples/e2e',
             '--match-pattern', 'js=checkVariable\\(\\w*,\\s*"([^"\']*)"', '--no-api'])
         .it('runs against a test file with a custom matcher', (ctx) => {
             expect(ctx.stdout).to.equal(customExpected)
@@ -136,7 +142,7 @@ describe('diff', () => {
     test
         .stdout()
         .command(['diff', '--file',
-            './test/utils/diff/samples/nodejs',
+            './test/utils/diff/samples/e2e',
             '--config-path', './test/commands/fixtures/testConfig.yml', '--no-api'])
         .it('runs against a test file with a custom matcher specified in a config file',
             (ctx) => {
@@ -155,14 +161,14 @@ describe('diff', () => {
             })
         })
         .command(['diff', '--file',
-            './test/utils/diff/samples/nodejs',
+            './test/utils/diff/samples/e2e',
             '--client-id', 'client', '--client-secret', 'secret', '--project', 'project'])
         .catch('Failed to authenticate with the DevCycle API. Check your credentials.')
         .it('runs with failed api authorization')
 
     test
         .stdout()
-        .command(['diff', '--file', './test/utils/diff/samples/nodejs', '--no-api', '--pr-link', 'https://example.com'])
+        .command(['diff', '--file', './test/utils/diff/samples/e2e', '--no-api', '--pr-link', 'https://example.com'])
         .it('runs against a test file and linkifies the output', (ctx) => {
             expect(ctx.stdout).to.equal(linkedExpected)
         })

--- a/test/utils/diff/parsers/android.test.ts
+++ b/test/utils/diff/parsers/android.test.ts
@@ -16,6 +16,30 @@ describe('android', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 9,
+            'mode': 'add',
+            'name': 'named-case'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 10,
+            'mode': 'add',
+            'name': 'reversed-named-case'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 11,
+            'mode': 'add',
+            'name': 'map-default-value'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 12,
+            'mode': 'add',
+            'name': 'hashmap-default-value'
         }
     ]
     it('identifies the correct variable usages in the Android sample diff', () => {

--- a/test/utils/diff/parsers/csharp.test.ts
+++ b/test/utils/diff/parsers/csharp.test.ts
@@ -16,6 +16,30 @@ describe('csharp', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.cs',
+            'line': 10,
+            'mode': 'add',
+            'name': 'user-object'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.cs',
+            'line': 11,
+            'mode': 'add',
+            'name': 'named-case'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.cs',
+            'line': 12,
+            'mode': 'add',
+            'name': 'unordered-named-case'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.cs',
+            'line': 13,
+            'mode': 'add',
+            'name': 'default-value-object'
         }
     ]
     it('identifies the correct variable usages in the C# sample diff', () => {

--- a/test/utils/diff/parsers/golang.test.ts
+++ b/test/utils/diff/parsers/golang.test.ts
@@ -16,6 +16,18 @@ describe('golang', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.go',
+            'line': 11,
+            'mode': 'add',
+            'name': 'user-object'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.go',
+            'line': 12,
+            'mode': 'add',
+            'name': 'user-named-object'
         }
     ]
     it('identifies the correct variable usages in the Go sample diff', () => {

--- a/test/utils/diff/parsers/java.test.ts
+++ b/test/utils/diff/parsers/java.test.ts
@@ -16,6 +16,18 @@ describe('java', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 10,
+            'mode': 'add',
+            'name': 'user-object'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.java',
+            'line': 11,
+            'mode': 'add',
+            'name': 'hashmap-default-value'
         }
     ]
     it('identifies the correct variable usages in the Java sample diff', () => {

--- a/test/utils/diff/parsers/javascript.test.ts
+++ b/test/utils/diff/parsers/javascript.test.ts
@@ -3,33 +3,33 @@ import * as path from 'node:path'
 import { parseFiles } from '../../../../src/utils/diff/parse'
 import { expect } from '@oclif/test'
 
-describe('ios', () => {
+describe('javascript', () => {
     const simpleMatchResult = [
         {
-            'fileName': 'test/utils/diff/sampleDiff.swift',
+            'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 1,
             'mode': 'add',
             'name': 'simple-case'
         },
         {
-            'fileName': 'test/utils/diff/sampleDiff.swift',
+            'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
         },
         {
-            'fileName': 'test/utils/diff/sampleDiff.swift',
-            'line': 9,
+            'fileName': 'test/utils/diff/sampleDiff.js',
+            'line': 8,
             'mode': 'add',
             'name': 'default-value-object'
         }
     ]
-    it('identifies the correct variable usages in the iOS sample diff', () => {
-        const parsedDiff = executeFileDiff(path.join(__dirname, '../samples/ios'))
+    it('identifies the correct variable usages in the JavaScript sample diff', () => {
+        const parsedDiff = executeFileDiff(path.join(__dirname, '../samples/javascript'))
         const results = parseFiles(parsedDiff)
 
         expect(results).to.deep.equal({
-            ios: simpleMatchResult,
+            javascript: simpleMatchResult,
         })
     })
 })

--- a/test/utils/diff/parsers/nodejs.test.ts
+++ b/test/utils/diff/parsers/nodejs.test.ts
@@ -34,6 +34,24 @@ describe('nodejs', () => {
             'line': 20,
             'mode': 'add',
             'name': 'multi-line-comment'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.js',
+            'line': 23,
+            'mode': 'add',
+            'name': 'user-object'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.js',
+            'line': 24,
+            'mode': 'add',
+            'name': 'user-constructor'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.js',
+            'line': 25,
+            'mode': 'add',
+            'name': 'multi-line-user-object'
         }]
     const nodeSimpleMatchRemoved = [
         {
@@ -64,7 +82,7 @@ describe('nodejs', () => {
                 ...nodeSimpleMatchAdded,
                 {
                     'fileName': 'test/utils/diff/sampleDiff.js',
-                    'line': 24,
+                    'line': 34,
                     'mode': 'add',
                     'name': 'renamed-case'
                 },
@@ -81,7 +99,7 @@ describe('nodejs', () => {
                 ...nodeSimpleMatchAdded,
                 {
                     'fileName': 'test/utils/diff/sampleDiff.js',
-                    'line': 24,
+                    'line': 34,
                     'mode': 'add',
                     'name': 'renamed-case'
                 },

--- a/test/utils/diff/parsers/php.test.ts
+++ b/test/utils/diff/parsers/php.test.ts
@@ -16,6 +16,24 @@ describe('php', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.php',
+            'line': 9,
+            'mode': 'add',
+            'name': 'named-case'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.php',
+            'line': 10,
+            'mode': 'add',
+            'name': 'user-object'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.php',
+            'line': 11,
+            'mode': 'add',
+            'name': 'default-value-object'
         }
     ]
     it('identifies the correct variable usages in the PHP sample diff', () => {

--- a/test/utils/diff/parsers/python.test.ts
+++ b/test/utils/diff/parsers/python.test.ts
@@ -29,6 +29,12 @@ describe('python', () => {
             'mode': 'add',
             'name': 'multi-line'
         },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.py',
+            'line': 10,
+            'mode': 'add',
+            'name': 'user-object'
+        }
     ]
 
     it('identifies the correct variable usages in the Python sample diff', () => {

--- a/test/utils/diff/parsers/ruby.test.ts
+++ b/test/utils/diff/parsers/ruby.test.ts
@@ -16,6 +16,12 @@ describe('ruby', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.rb',
+            'line': 9,
+            'mode': 'add',
+            'name': 'user-object'
         }
     ]
     it('identifies the correct variable usages in the Ruby sample diff', () => {

--- a/test/utils/diff/samples/android
+++ b/test/utils/diff/samples/android
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.java
-@@ -1,1 +1,8 @@
+@@ -1,1 +1,12 @@
 +dvcClient.variable("simple-case", false)
 +
 +dvcClient
@@ -12,3 +12,7 @@ index 00000000..ed8ee4ab
 +        true
 +    )
 +
++dvcClient.variable(key="named-case", default=false)
++dvcClient.variable(default=false, key="reversed-named-case")
++dvcClient.variable("map-default-value", mapOf('foo' to 'bar'))
++dvcClient.variable("hashmap-default-value", new HashMap<String, String>())

--- a/test/utils/diff/samples/csharp
+++ b/test/utils/diff/samples/csharp
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.cs
-@@ -1,1 +1,9 @@
+@@ -1,1 +1,13 @@
 +dvcClient.VariableAsync(user, "simple-case", true)
 +
 +dvcClient
@@ -13,3 +13,7 @@ index 00000000..ed8ee4ab
 +        true
 +    )
 +
++dvcClient.VariableAsync(new User("user_id"), "user-object", true)
++dvcClient.VariableAsync(user=user, key="named-case", default=true)
++dvcClient.VariableAsync(key="unordered-named-case", default=true, user=user)
++dvcClient.VariableAsync(user, "default-value-object", new { Foo = "Bar" })

--- a/test/utils/diff/samples/e2e
+++ b/test/utils/diff/samples/e2e
@@ -6,10 +6,11 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.js
-@@ -1,1 +1,34 @@
+@@ -1,1 +1,25 @@
 -dvcClient.variable(user, "simple-case", true)
 +dvcClient.variable(user, "simple-case", true)
-+dvcClient.variable(user, "simple-case", false)
++dvcClient.variable(user, "duplicate-case", true)
++dvcClient.variable(user, "duplicate-case", false)
 +
 +dvcClient.variable(user, 'single-quotes', "word")
 +
@@ -30,15 +31,5 @@ index 00000000..ed8ee4ab
 + * dvcClient.variable(user, "multi-line-comment", false)
 + */
 +
-+dvcClient.variable({ user_id: "id", email: "blah" }, "user-object", true)
-+dvcClient.variable(new User("user_id"), "user-constructor", true)
-+dvcClient.variable(
-+   {
-+      user_id: "id",
-+      email: "blah"
-+    },
-+   "multi-line-user-object",
-+   true
-+)
 +dvcClient.variable(user, VARIABLES.ENUM_VARIABLE, true)
 +dvc.variable(user, "renamed-case", true)

--- a/test/utils/diff/samples/golang
+++ b/test/utils/diff/samples/golang
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.go
-@@ -1,1 +1,10 @@
+@@ -1,1 +1,12 @@
 +dvcClient.DevcycleApi.Variable(auth, user, "simple-case", true)
 +
 +dvcClient
@@ -14,3 +14,5 @@ index 00000000..ed8ee4ab
 +        "multi-line",
 +        true
 +    )
++dvcClient.DevcycleApi.Variable(auth, {user_id: "my_user"}, "user-object", true)
++dvcClient.DevcycleApi.Variable(auth, devcycle.UserData{UserId: "test"}, "user-named-object", true)

--- a/test/utils/diff/samples/ios
+++ b/test/utils/diff/samples/ios
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.swift
-@@ -1,1 +1,8 @@
+@@ -1,1 +1,9 @@
 +dvcClient.variable(key: "simple-case", defaultValue: true)
 +
 +dvcClient
@@ -12,3 +12,4 @@ index 00000000..ed8ee4ab
 +        defaultValue: true
 +    )
 +
++dvcClient.variable(key: "default-value-object", defaultValue: ["key": "value"])

--- a/test/utils/diff/samples/java
+++ b/test/utils/diff/samples/java
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.java
-@@ -1,1 +1,9 @@
+@@ -1,1 +1,11 @@
 +dvcClient.variable(user, "simple-case", false)
 +
 +dvcClient
@@ -13,3 +13,5 @@ index 00000000..ed8ee4ab
 +        true
 +    )
 +
++dvcClient.variable(new User("user_id"), "user-object", false)
++dvcClient.variable(user, "hashmap-default-value", new HashMap<String, String>())

--- a/test/utils/diff/samples/javascript
+++ b/test/utils/diff/samples/javascript
@@ -1,0 +1,14 @@
+diff --git a/test/utils/diff/sampleDiff.js b/test/utils/diff/sampleDiff.js
+new file mode 100644
+index 00000000..ed8ee4ab
+--- /dev/null
++++ b/test/utils/diff/sampleDiff.js
+@@ -1,1 +1,8 @@
++dvcClient.variable("simple-case", true)
++
++dvcClient.variable(
++        "multi-line",
++        true
++    )
++
++dvcClient.variable("default-value-object", { key: "value", foo: "bar" })

--- a/test/utils/diff/samples/php
+++ b/test/utils/diff/samples/php
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.php
-@@ -1,1 +1,8 @@
+@@ -1,1 +1,11 @@
 +$dvcClient->variable($user_data, "simple-case", "default")
 +
 +$dvcClient->variable(
@@ -12,3 +12,6 @@ index 00000000..ed8ee4ab
 +        "default"
 +    )
 +
++$dvcClient->variable(user: $user_data, key: "named-case", defaultValue: "default")
++$dvcClient->variable(array("user_id"=>"foo"), "user-object", "default")
++$dvcClient->variable($user, "default-value-object", array("foo"=>"bar"))

--- a/test/utils/diff/samples/python
+++ b/test/utils/diff/samples/python
@@ -3,13 +3,14 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.py
-@@ -1,1 +1,8 @@
+@@ -1,1 +1,10 @@
 +dvcClient.variable(user, 'simple-case', True)
-+dvcClient.variable(user=user, key="named-case", default="default")
-+dvcClient.variable(key="named-case-reversed", user=user, default=True)
++dvcClient.variable(user=user, key="named-case", defaultValue="default")
++dvcClient.variable(key="named-case-reversed", user=user, defaultValue=True)
 +dvcClient.variable(
 +        user,
 +        'multi-line',
 +        True
 +    )
 +
++dvcClient.variable(UserData(user_id="id", email="blah"), "user-object", True)

--- a/test/utils/diff/samples/ruby
+++ b/test/utils/diff/samples/ruby
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.rb
-@@ -1,1 +1,7 @@
+@@ -1,1 +1,9 @@
 +dvcClient.variable(user, "simple-case", true)
 +
 +dvcClient.variable(
@@ -12,3 +12,4 @@ index 00000000..ed8ee4ab
 +        true
 +    )
 +
++dvcClient.variable(DevCycle::UserData.new({user_id: 'user_id_example'}), "user-object", true)


### PR DESCRIPTION
- Update parsers to have `orderedParameterPatterns` and `namedParameterPatternMap`. One or both of these are used to build a pattern to match ordered and/or named parameters
- Update user capture pattern for each language parser