### PR TITLE
DVC-2089 detect unknown variables

### DIFF
--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -18,7 +18,10 @@ const EMOJI = {
 
 type MatchesByType = {
     add: Record<string, VariableMatch[]>,
-    remove: Record<string, VariableMatch[]>
+    remove: Record<string, VariableMatch[]>,
+    addUnknown: Record<string, VariableMatch[]>,
+    removeUnknown: Record<string, VariableMatch[]>
+
 }
 
 type MatchEnriched = {
@@ -30,7 +33,9 @@ type MatchesByTypeEnriched = {
     add: Record<string, MatchEnriched>
     remove: Record<string, MatchEnriched>,
     notFoundAdd: Record<string, MatchEnriched>,
-    notFoundRemove: Record<string, MatchEnriched>
+    notFoundRemove: Record<string, MatchEnriched>,
+    addUnknown: Record<string, MatchEnriched>,
+    removeUnknown: Record<string, MatchEnriched>
 }
 
 export default class Diff extends Base {
@@ -41,7 +46,7 @@ export default class Diff extends Base {
     static examples = [
         '<%= config.bin %> <%= command.id %>',
         '<%= config.bin %> <%= command.id %> ' +
-            '--match-pattern javascript="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
+        '--match-pattern javascript="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
     ]
 
     static flags = {
@@ -105,13 +110,16 @@ export default class Diff extends Base {
     private getMatchesByType(matchesBySdk: Record<string, VariableMatch[]>): MatchesByType {
         const matchesByType: MatchesByType = {
             add: {},
-            remove: {}
+            remove: {},
+            addUnknown: {},
+            removeUnknown: {}
         }
         Object.values(matchesBySdk).forEach((matches) => {
             matches.forEach((match) => {
-                matchesByType[match.mode] ??= {}
-                matchesByType[match.mode][match.name] ??= []
-                matchesByType[match.mode][match.name].push(match)
+                const mode: keyof MatchesByType = `${match.mode}${match.kind === 'unknown' ? 'Unknown' : ''}`
+                matchesByType[mode] ??= {}
+                matchesByType[mode][match.name] ??= []
+                matchesByType[mode][match.name].push(match)
             })
         })
         return matchesByType
@@ -122,7 +130,9 @@ export default class Diff extends Base {
             add: {},
             remove: {},
             notFoundAdd: {},
-            notFoundRemove: {}
+            notFoundRemove: {},
+            addUnknown: {},
+            removeUnknown: {}
         }
 
         const fetchAndCategorize = async (
@@ -161,13 +171,37 @@ export default class Diff extends Base {
             fetchAndCategorize(matchesByType.remove, 'remove')
         ])
 
+        const enrichedAddUnknown: Record<string, MatchEnriched> = {}
+        const enrichedRemoveUnknown: Record<string, MatchEnriched> = {}
+
+        for (const key of Object.keys(matchesByType.addUnknown)) {
+            enrichedAddUnknown[key] = {
+                variable: null,
+                matches: matchesByType.addUnknown[key]
+            }
+        }
+
+        for (const key of Object.keys(matchesByType.removeUnknown)) {
+            enrichedRemoveUnknown[key] = {
+                variable: null,
+                matches: matchesByType.removeUnknown[key]
+            }
+        }
+
+        categories.addUnknown = enrichedAddUnknown
+        categories.removeUnknown = enrichedRemoveUnknown
+
         return categories
     }
 
     private formatOutput(matchesByTypeEnriched: MatchesByTypeEnriched, prLink?: string) {
-        const totalAdditions = Object.keys(matchesByTypeEnriched.add).length
-        const totalDeletions = Object.keys(matchesByTypeEnriched.remove).length
+
+        const additions = { ...matchesByTypeEnriched.add, ...matchesByTypeEnriched.addUnknown }
+        const deletions = { ...matchesByTypeEnriched.remove, ...matchesByTypeEnriched.removeUnknown }
+        const totalAdditions = Object.keys(additions).length
+        const totalDeletions = Object.keys(deletions).length
         const totalNotices = Object.keys(matchesByTypeEnriched.notFoundAdd).length
+            + Object.keys(matchesByTypeEnriched.addUnknown).length
         const totalCleanup = Object.keys(matchesByTypeEnriched.notFoundRemove).length
 
         this.log('\nDevCycle Variable Changes:\n')
@@ -187,12 +221,12 @@ export default class Diff extends Base {
 
         if (totalAdditions) {
             this.log(`\n${EMOJI.add} Added\n`)
-            this.logMatches(matchesByTypeEnriched.add, 'add', prLink)
+            this.logMatches(additions, 'add', prLink)
         }
 
         if (totalDeletions) {
             this.log(`\n${EMOJI.remove} Removed\n`)
-            this.logMatches(matchesByTypeEnriched.remove, 'remove', prLink)
+            this.logMatches(deletions, 'remove', prLink)
         }
 
         if (totalCleanup) {
@@ -205,9 +239,17 @@ export default class Diff extends Base {
     private logNotices(
         matchesByTypeEnriched: MatchesByTypeEnriched
     ) {
+        let offset = 0
         Object.entries(matchesByTypeEnriched.notFoundAdd).forEach(([variableName], idx) => {
             this.log(`  ${idx + 1}. Variable "${variableName}" does not exist on DevCycle`)
+            offset = idx + 1
         })
+
+        Object.entries({ ...matchesByTypeEnriched.addUnknown, ...matchesByTypeEnriched.removeUnknown })
+            .forEach(([variableName], idx) => {
+                this.log(`  ${offset + idx + 1}. Variable "${
+                    variableName}" could not be identified. Try adding an alias.`)
+            })
     }
 
     private logCleanup(
@@ -225,9 +267,15 @@ export default class Diff extends Base {
     ) {
         Object.entries(matchesByVariable).forEach(([variableName, enriched], idx) => {
             const matches = enriched.matches
-            const hasNotice = this.useApi() && !enriched.variable
+            const hasNotice = mode === 'add' && ((this.useApi() && !enriched.variable)
+                || enriched.matches.some((match) => match.kind === 'unknown'))
+
+            const hasCleanup = mode === 'remove' && this.useApi() && !enriched.variable
+
             this.log(`  ${idx + 1}. ${variableName}${
-                hasNotice ? ` ${mode === 'add' ? EMOJI.notice : EMOJI.cleanup}` : ''}`)
+                hasNotice ? ` ${EMOJI.notice}` : ''}${
+                hasCleanup ? ` ${EMOJI.cleanup}` : ''}`)
+
             if (enriched.variable?.type) {
                 this.log(`\t   Type: ${enriched.variable.type}`)
             }

--- a/src/utils/diff/parsers/android/index.ts
+++ b/src/utils/diff/parsers/android/index.ts
@@ -12,6 +12,8 @@ export class AndroidParser extends BaseParser {
         defaultValueCapturePattern
     ]
 
+    variableParamPosition = 0
+
     namedParameterDelimiter = '='
     namedParameterPatternMap = {
         key: variableNameCapturePattern,

--- a/src/utils/diff/parsers/csharp/index.ts
+++ b/src/utils/diff/parsers/csharp/index.ts
@@ -14,6 +14,8 @@ export class CsharpParser extends BaseParser {
         defaultValueCapturePattern
     ]
 
+    variableParamPosition = 1
+
     namedParameterPatternMap = {
         user: userCapturePattern,
         key: variableNameCapturePattern,

--- a/src/utils/diff/parsers/custom.ts
+++ b/src/utils/diff/parsers/custom.ts
@@ -1,10 +1,11 @@
 import { BaseParser } from './common'
-import { ParseOptions } from './types'
+import { MatchKind, ParseOptions } from './types'
 
 export class CustomParser extends BaseParser {
     identity = 'custom'
     variableMethodPattern = new RegExp('')
     customPatterns: string[]
+    variableParamPosition = null
 
     constructor(extension: string, options: ParseOptions) {
         super(extension, options)
@@ -16,12 +17,12 @@ export class CustomParser extends BaseParser {
         this.customPatterns = options.matchPatterns[extension]
     }
 
-    match(content: string): RegExpExecArray | null {
-        for (const pattern of this.customPatterns) {
-            const match = (new RegExp(pattern)).exec(content)
-            if (match) return match
-        }
-
-        return null
+    protected override buildRegexPatterns(): { pattern: RegExp, kind: MatchKind }[] {
+        return this.customPatterns.map((pattern) => {
+            return {
+                pattern: new RegExp(pattern),
+                kind: 'regular'
+            }
+        })
     }
 }

--- a/src/utils/diff/parsers/golang/index.ts
+++ b/src/utils/diff/parsers/golang/index.ts
@@ -14,6 +14,7 @@ export class GolangParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 2
 
     commentCharacters = ['//', '/*']
 

--- a/src/utils/diff/parsers/ios/index.ts
+++ b/src/utils/diff/parsers/ios/index.ts
@@ -14,4 +14,6 @@ export class IosParser extends BaseParser {
     }
 
     commentCharacters = ['///', '/**']
+
+    variableParamPosition = null
 }

--- a/src/utils/diff/parsers/java/index.ts
+++ b/src/utils/diff/parsers/java/index.ts
@@ -12,6 +12,7 @@ export class JavaParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 1
 
     commentCharacters = ['/**', '*']
 }

--- a/src/utils/diff/parsers/javascript/index.ts
+++ b/src/utils/diff/parsers/javascript/index.ts
@@ -10,6 +10,7 @@ export class JavascriptParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 0
 
     commentCharacters = ['//', '/*']
 }

--- a/src/utils/diff/parsers/nodejs/index.ts
+++ b/src/utils/diff/parsers/nodejs/index.ts
@@ -13,6 +13,7 @@ export class NodeParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition: number | null = 1
 
     commentCharacters = ['//', '/*']
 }

--- a/src/utils/diff/parsers/php/index.ts
+++ b/src/utils/diff/parsers/php/index.ts
@@ -12,6 +12,7 @@ export class PhpParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 1
 
     namedParameterDelimiter = ':'
     namedParameterPatternMap = {

--- a/src/utils/diff/parsers/python/index.ts
+++ b/src/utils/diff/parsers/python/index.ts
@@ -14,6 +14,8 @@ export class PythonParser extends BaseParser {
         defaultValueCapturePattern
     ]
 
+    variableParamPosition = 1
+
     namedParameterDelimiter = '='
     namedParameterPatternMap = {
         key: variableNameCapturePattern,

--- a/src/utils/diff/parsers/react/index.ts
+++ b/src/utils/diff/parsers/react/index.ts
@@ -11,6 +11,7 @@ export class ReactParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 0
 
     commentCharacters = ['//', '/*', '{/*']
 }

--- a/src/utils/diff/parsers/ruby/index.ts
+++ b/src/utils/diff/parsers/ruby/index.ts
@@ -12,6 +12,7 @@ export class RubyParser extends BaseParser {
         variableNameCapturePattern,
         defaultValueCapturePattern
     ]
+    variableParamPosition = 1
 
     commentCharacters = ['#']
 }

--- a/src/utils/diff/parsers/types.ts
+++ b/src/utils/diff/parsers/types.ts
@@ -1,11 +1,14 @@
+export type MatchKind = 'regular' | 'unknown'
 export type VariableMatch = {
     name: string,
     line: number,
     fileName: string,
-    mode: 'add' | 'remove'
+    mode: 'add' | 'remove',
+    kind: MatchKind
 }
 
 export type ParseOptions = {
     clientNames?: string[],
     matchPatterns?: Record<string, string[]>
 }
+

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -122,6 +122,29 @@ The following variables that do not exist in DevCycle were cleaned up:
   1. no-exists2
 `
 
+const unknownExpected = `
+DevCycle Variable Changes:
+
+⚠️   1 Variable With Notices
+✅  1 Variable Added
+❌  1 Variable Removed
+
+⚠️  Notices
+
+  1. Variable "SOME_ADDITION" could not be identified. Try adding an alias.
+  2. Variable "VARIABLES.SOME_REMOVAL" could not be identified. Try adding an alias.
+
+✅ Added
+
+  1. SOME_ADDITION ⚠️
+	   Location: test/utils/diff/sampleDiff.js:L1
+
+❌ Removed
+
+  1. VARIABLES.SOME_REMOVAL
+	   Location: test/utils/diff/sampleDiff.js:L1
+`
+
 describe('diff', () => {
     test
         .stdout()
@@ -206,4 +229,13 @@ describe('diff', () => {
         .it('enriches output with API data', (ctx) => {
             expect(ctx.stdout).to.equal(apiExpected)
         })
+
+    test
+        .stdout()
+        .command(['diff', '--file',
+            './test/utils/diff/samples/aliases/aliased', '--no-api'])
+        .it('identifies unknown variables and warns about them',
+            (ctx) => {
+                expect(ctx.stdout).to.equal(unknownExpected)
+            })
 })

--- a/test/utils/diff/parse.test.ts
+++ b/test/utils/diff/parse.test.ts
@@ -21,6 +21,7 @@ describe('parse', () => {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }],
             })
@@ -35,6 +36,7 @@ describe('parse', () => {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'remove',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }],
             })
@@ -49,12 +51,14 @@ describe('parse', () => {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'new-variable'
                 },
                 {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'remove',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }],
             })
@@ -69,12 +73,14 @@ describe('parse', () => {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 },
                 {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 176,
                     'mode': 'remove',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }],
             })
@@ -85,19 +91,20 @@ describe('parse', () => {
         it('identifies no change when addition is commented', () => {
             const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/add-comment'))
             const results = parseFiles(parsedDiff)
-    
+
             expect(results).to.deep.equal({})
         })
 
         it('identifies addition when line is uncommented', () => {
             const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/uncomment'))
             const results = parseFiles(parsedDiff)
-    
+
             expect(results).to.deep.equal({
                 nodejs: [{
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 177,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }]
             })
@@ -106,12 +113,13 @@ describe('parse', () => {
         it('identifies deletion when line is commented', () => {
             const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/comment'))
             const results = parseFiles(parsedDiff)
-    
+
             expect(results).to.deep.equal({
                 nodejs: [{
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 177,
                     'mode': 'remove',
+                    'kind': 'regular',
                     'name': 'variable-key'
                 }]
             })
@@ -120,19 +128,21 @@ describe('parse', () => {
         it('identifies change when parameter is commented', () => {
             const parsedDiff = executeFileDiff(path.join(__dirname, './samples/comments/param-comment'))
             const results = parseFiles(parsedDiff)
-    
+
             expect(results).to.deep.equal({
                 nodejs: [
                     {
                         'fileName': 'services/api/src/organizations/organizations.controller.ts',
                         'line': 177,
                         'mode': 'add',
+                        'kind': 'regular',
                         'name': 'new-variable'
                     },
                     {
                         'fileName': 'services/api/src/organizations/organizations.controller.ts',
                         'line': 177,
                         'mode': 'remove',
+                        'kind': 'regular',
                         'name': 'variable-key'
                     }
                 ]

--- a/test/utils/diff/parsers/android.test.ts
+++ b/test/utils/diff/parsers/android.test.ts
@@ -9,36 +9,42 @@ describe('android', () => {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 9,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'reversed-named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 11,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'map-default-value'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 12,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'hashmap-default-value'
         }
     ]

--- a/test/utils/diff/parsers/csharp.test.ts
+++ b/test/utils/diff/parsers/csharp.test.ts
@@ -9,36 +9,42 @@ describe('csharp', () => {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 11,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 12,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'unordered-named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.cs',
             'line': 13,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'default-value-object'
         }
     ]

--- a/test/utils/diff/parsers/golang.test.ts
+++ b/test/utils/diff/parsers/golang.test.ts
@@ -9,24 +9,28 @@ describe('golang', () => {
             'fileName': 'test/utils/diff/sampleDiff.go',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.go',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.go',
             'line': 11,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.go',
             'line': 12,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-named-object'
         }
     ]

--- a/test/utils/diff/parsers/ios.test.ts
+++ b/test/utils/diff/parsers/ios.test.ts
@@ -8,12 +8,14 @@ describe('ios', () => {
         {
             'fileName': 'test/utils/diff/sampleDiff.swift',
             'line': 1,
+            'kind': 'regular',
             'mode': 'add',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.swift',
             'line': 3,
+            'kind': 'regular',
             'mode': 'add',
             'name': 'multi-line'
         },
@@ -21,6 +23,7 @@ describe('ios', () => {
             'fileName': 'test/utils/diff/sampleDiff.swift',
             'line': 9,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'default-value-object'
         }
     ]

--- a/test/utils/diff/parsers/java.test.ts
+++ b/test/utils/diff/parsers/java.test.ts
@@ -9,24 +9,28 @@ describe('java', () => {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.java',
             'line': 11,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'hashmap-default-value'
         }
     ]

--- a/test/utils/diff/parsers/javascript.test.ts
+++ b/test/utils/diff/parsers/javascript.test.ts
@@ -9,18 +9,21 @@ describe('javascript', () => {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 8,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'default-value-object'
         }
     ]

--- a/test/utils/diff/parsers/nodejs.test.ts
+++ b/test/utils/diff/parsers/nodejs.test.ts
@@ -9,55 +9,72 @@ describe('nodejs', () => {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 2,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 4,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'single-quotes'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 20,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line-comment'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 23,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 24,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-constructor'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 25,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line-user-object'
-        }]
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.js',
+            'line': 33,
+            'mode': 'add',
+            'kind': 'unknown',
+            'name': 'VARIABLES.ENUM_VARIABLE'
+        }
+    ]
     const nodeSimpleMatchRemoved = [
         {
             'fileName': 'test/utils/diff/sampleDiff.js',
             'line': 1,
             'mode': 'remove',
+            'kind': 'regular',
             'name': 'simple-case'
         }
     ]
@@ -84,6 +101,7 @@ describe('nodejs', () => {
                     'fileName': 'test/utils/diff/sampleDiff.js',
                     'line': 34,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'renamed-case'
                 },
                 ...nodeSimpleMatchRemoved
@@ -101,6 +119,7 @@ describe('nodejs', () => {
                     'fileName': 'test/utils/diff/sampleDiff.js',
                     'line': 34,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'renamed-case'
                 },
                 ...nodeSimpleMatchRemoved
@@ -118,6 +137,7 @@ describe('nodejs', () => {
                     'fileName': 'test/utils/diff/sampleDiff.js',
                     'line': 6,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'func-proxy'
                 }]
         })
@@ -132,7 +152,31 @@ describe('nodejs', () => {
                     'fileName': 'services/api/src/organizations/organizations.controller.ts',
                     'line': 177,
                     'mode': 'add',
+                    'kind': 'regular',
                     'name': 'optional-accessor'
+                }
+            ]
+        })
+    })
+
+    it('identifies unknown variables', () => {
+        const parsedDiff = executeFileDiff(path.join(__dirname, '../samples/aliases/aliased'))
+        const results = parseFiles(parsedDiff)
+        expect(results).to.deep.equal({
+            nodejs: [
+                {
+                    'fileName': 'test/utils/diff/sampleDiff.js',
+                    'line': 1,
+                    'mode': 'add',
+                    'kind': 'unknown',
+                    'name': 'SOME_ADDITION'
+                },
+                {
+                    'fileName': 'test/utils/diff/sampleDiff.js',
+                    'line': 1,
+                    'mode': 'remove',
+                    'kind': 'unknown',
+                    'name': 'VARIABLES.SOME_REMOVAL'
                 }
             ]
         })

--- a/test/utils/diff/parsers/php.test.ts
+++ b/test/utils/diff/parsers/php.test.ts
@@ -9,30 +9,35 @@ describe('php', () => {
             'fileName': 'test/utils/diff/sampleDiff.php',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.php',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.php',
             'line': 9,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.php',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.php',
             'line': 11,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'default-value-object'
         }
     ]

--- a/test/utils/diff/parsers/python.test.ts
+++ b/test/utils/diff/parsers/python.test.ts
@@ -9,30 +9,35 @@ describe('python', () => {
             'fileName': 'test/utils/diff/sampleDiff.py',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.py',
             'line': 2,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'named-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.py',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'named-case-reversed'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.py',
             'line': 4,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.py',
             'line': 10,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         }
     ]

--- a/test/utils/diff/parsers/react.test.ts
+++ b/test/utils/diff/parsers/react.test.ts
@@ -9,12 +9,14 @@ describe('react', () => {
             'fileName': 'test/utils/diff/sampleDiff.jsx',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.jsx',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         }
     ]

--- a/test/utils/diff/parsers/ruby.test.ts
+++ b/test/utils/diff/parsers/ruby.test.ts
@@ -9,18 +9,21 @@ describe('ruby', () => {
             'fileName': 'test/utils/diff/sampleDiff.rb',
             'line': 1,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'simple-case'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.rb',
             'line': 3,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'multi-line'
         },
         {
             'fileName': 'test/utils/diff/sampleDiff.rb',
             'line': 9,
             'mode': 'add',
+            'kind': 'regular',
             'name': 'user-object'
         }
     ]

--- a/test/utils/diff/samples/aliases/aliased
+++ b/test/utils/diff/samples/aliases/aliased
@@ -1,0 +1,11 @@
+diff --git a/test/utils/diff/sampleDiff b/test/utils/diff/sampleDiff
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/test/utils/diff/sampleDiff.js b/test/utils/diff/sampleDiff.js
+new file mode 100644
+index 00000000..ed8ee4ab
+--- /dev/null
++++ b/test/utils/diff/sampleDiff.js
+@@ -1,1 +1,21 @@
++dvcClient.variable(user, SOME_ADDITION, true)
+-dvcClient.variable(user, VARIABLES.SOME_REMOVAL, false)

--- a/test/utils/diff/samples/e2e
+++ b/test/utils/diff/samples/e2e
@@ -31,5 +31,4 @@ index 00000000..ed8ee4ab
 + * dvcClient.variable(user, "multi-line-comment", false)
 + */
 +
-+dvcClient.variable(user, VARIABLES.ENUM_VARIABLE, true)
 +dvc.variable(user, "renamed-case", true)


### PR DESCRIPTION
Add detection for variables that are "unknown" ie. are themselves variables, and not plain strings.

Collect these cases and output them as "notices" in the diff command, alerting the user that they should add an alias in order to detect the variable.