### PR TITLE
add show-regex option to diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Print a diff of DevCycle variable usage between two versions of your code.
 USAGE
   $ dvc diff [DIFF-PATTERN] [--config-path <value>] [--auth-path <value>] [--client-id <value>]
     [--client-secret <value>] [--project <value>] [--no-api] [-f <value>] [--client-name <value>] [--match-pattern
-    <value>] [--var-alias <value>] [--format console|markdown]
+    <value>] [--var-alias <value>] [--format console|markdown] [--show-regex]
 
 ARGUMENTS
   DIFF-PATTERN  A "git diff"-compatible diff pattern, eg. "branch1 branch2"
@@ -62,6 +62,7 @@ FLAGS
   --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
                               warnings about missing credentials.
   --project=<value>           Project key to use for the DevCycle API requests
+  --show-regex                Output the regex pattern used to find variable usage
   --var-alias=<value>...      Aliases to use when identifying variables in your code. Should contain a code reference
                               mapped to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
 

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -76,6 +76,9 @@ export default class Diff extends Base {
             default: 'console',
             options: ['console', 'markdown'],
             description: 'Format to output the diff results in.'
+        }),
+        'show-regex': Flags.boolean({
+            description: 'Output the regex pattern used to find variable usage'
         })
     }
 
@@ -112,7 +115,8 @@ export default class Diff extends Base {
 
         const matchesBySdk = parseFiles(parsedDiff, {
             clientNames: [...clientNamesFromConfig, ...(flags['client-name'] || [])],
-            matchPatterns
+            matchPatterns,
+            printPatterns: flags['show-regex']
         })
 
         const variableAliases = (flags['var-alias'] || []).reduce((map, value) => {

--- a/src/utils/diff/parse.ts
+++ b/src/utils/diff/parse.ts
@@ -28,12 +28,20 @@ export const parseFiles = (files: parse.File[], options: ParseOptions = {}): Rec
         ALL_PARSERS[extension] = [...(ALL_PARSERS[extension] ?? []), CustomParser]
     }
 
+    const printed: Record<string, boolean> = {}
+
     for (const file of files) {
         const fileExtension = file.to?.split('.').pop() ?? ''
         const Parsers = ALL_PARSERS[fileExtension] || []
 
         for (const Parser of Parsers) {
             const parser = new Parser(fileExtension, options)
+
+            if (options.printPatterns && !printed[parser.identity]) {
+                printed[parser.identity] = true
+                parser.printRegexPattern()
+            }
+
             const result = parser.parse(file)
             if (result.length > 0) {
                 resultsByLanguage[parser.identity] ??= []

--- a/src/utils/diff/parsers/common.ts
+++ b/src/utils/diff/parsers/common.ts
@@ -185,6 +185,10 @@ export abstract class BaseParser {
         return { added, removed }
     }
 
+    printRegexPattern(): void {
+        console.log(`Pattern for ${this.identity} parser: ${this.buildRegexPattern().source}`)
+    }
+
     match(content: string): MatchResult | null {
         const pattern = this.buildRegexPattern()
 

--- a/src/utils/diff/parsers/types.ts
+++ b/src/utils/diff/parsers/types.ts
@@ -9,6 +9,7 @@ export type VariableMatch = {
 
 export type ParseOptions = {
     clientNames?: string[],
-    matchPatterns?: Record<string, string[]>
+    matchPatterns?: Record<string, string[]>,
+    printPatterns?: boolean
 }
 

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -304,4 +304,16 @@ describe('diff', () => {
             (ctx) => {
                 expect(ctx.stdout).to.equal(formattedExpected)
             })
+    test
+        .stdout()
+        .command(['diff', '--file',
+            './test/utils/diff/samples/optional-accessor', '--no-api', '--show-regex'
+        ])
+        .it('outputs the regex patterns used for matching',
+            (ctx) => {
+                expect(ctx.stdout).to.contain('Pattern for nodejs parser')
+                expect(ctx.stdout).to.contain('Pattern for react parser')
+                expect(ctx.stdout).to.contain('Pattern for javascript parser')
+
+            })
 })


### PR DESCRIPTION
Adds a flag that lets you print all the patterns used while evaluating your diff:

Pattern for nodejs parser: (?:dvcClient)\??\.variable\(\s*(?:\w*|{[^})]*}|new[^)]*\))\s*,\s*([^,)]*)\s*,\s*(?:[^),]*|{[^}]*})\)
Pattern for react parser: useVariable\(\s*([^,)]*)\s*,\s*(?:[^),]*|{[^}]*})\)
Pattern for javascript parser: (?:dvcClient)\??\.variable\(\s*([^,)]*)\s*,\s*(?:[^),]*|{[^}]*})\)

DevCycle Variable Changes:

✅  0 Variables Added
❌  0 Variables Removed