### PR TITLE
Identify variable aliases found with custom matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ codeInsights:
       'VARIABLES.ENABLE_V1': 'enable-v1'
     ## fully override the regex patterns used to match variables for a specific file extension
     ## each pattern should contain exactly one capture group which matches on the key of the variable
+    ## make sure the captured value contains the entire key parameter (including quotes, if applicable)
     matchPatterns:
         ## file extension to override for, containing a list of patterns to use
         js:
@@ -164,10 +165,3 @@ codeInsights:
 ## the default project key to use for commands that interact with the DevCycle API.
 project: my-project
 ```
-
-# Development
-
-## Publishing a new version
-1. Checkout the latest `main` branch and bump the CLI version, `npm version patch`. Make note of the tag created.
-2. Push the tag and version commit that were created, `git push && git push origin vX.X.X`
-3. Publish to NPM, `npm publish --access public`

--- a/src/utils/diff/parsers/custom.ts
+++ b/src/utils/diff/parsers/custom.ts
@@ -24,8 +24,9 @@ export class CustomParser extends BaseParser {
             const matches = new RegExp(pattern).exec(content)
             if (matches && minIndex > matches.index) {
                 minIndex = matches.index
-                const varName = matches[1] || matches[2]
+                const varName = (matches[1] || matches[2]).trim()
                 minMatch = {
+                    isUnknown: !varName.match(/^["'].*["']$/),
                     // position or named parameter match
                     name: varName.replace(/["']/g, ''),
                     content: matches[0],

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -64,6 +64,18 @@ DevCycle Variable Changes:
 	   Location: test/utils/diff/sampleDiff.js:L1
 `
 
+const aliasedCustomExpected = `
+DevCycle Variable Changes:
+
+🟢  1 Variable Added
+🔴  0 Variables Removed
+
+🟢 Added
+
+  1. my-variable
+	   Location: test/utils/diff/sampleDiff.jsx:L1
+`
+
 const linkedExpected = `
 DevCycle Variable Changes:
 
@@ -192,7 +204,7 @@ describe('diff', () => {
         .stdout()
         .command(['diff', '--file',
             './test/utils/diff/samples/e2e',
-            '--match-pattern', 'js=checkVariable\\(\\w*,\\s*"([^"\']*)"', '--no-api'])
+            '--match-pattern', 'js=checkVariable\\(\\w*,\\s*([^,)]*)', '--no-api'])
         .it('runs against a test file with a custom matcher', (ctx) => {
             expect(ctx.stdout).to.equal(customExpected)
         })
@@ -206,6 +218,17 @@ describe('diff', () => {
             (ctx) => {
                 expect(ctx.stdout).to.equal(customExpected)
             })
+
+    test
+        .stdout()
+        .command(['diff', '--file',
+            './test/utils/diff/samples/custom-pattern',
+            '--match-pattern', 'jsx=useDVCVariable\\(\\s*([^,)]*)\\s*,\\s*(?:[^),]*|{[^}]*})\\)',
+            '--var-alias', 'ALIASED_VARIABLE=my-variable',
+            '--no-api'])
+        .it('identifies an aliased variable with a custom matcher', (ctx) => {
+            expect(ctx.stdout).to.equal(aliasedCustomExpected)
+        })
 
     test
         .nock(AUTH_URL, (api) => {

--- a/test/commands/fixtures/customMatcherConfig.yml
+++ b/test/commands/fixtures/customMatcherConfig.yml
@@ -1,4 +1,4 @@
 codeInsights:
   matchPatterns:
     js:
-      - checkVariable\(\w*,\s*"([^"']*)"
+      - checkVariable\(\w*,\s*([^,)]*)

--- a/test/utils/diff/parsers/nodejs.test.ts
+++ b/test/utils/diff/parsers/nodejs.test.ts
@@ -118,7 +118,7 @@ describe('nodejs', () => {
 
     it('identifies the correct variables using a custom pattern', () => {
         const parsedDiff = executeFileDiff(path.join(__dirname, '../samples/nodejs'))
-        const results = parseFiles(parsedDiff, { matchPatterns: { js: ['checkVariable\\(\\w*,\\s*"([^"\']*)"'] } })
+        const results = parseFiles(parsedDiff, { matchPatterns: { js: ['checkVariable\\(\\w*,\\s*([^,)]*)\\s*'] } })
         expect(results).to.deep.equal({
             nodejs: nodeSimpleMatchResult,
             custom: [
@@ -134,7 +134,7 @@ describe('nodejs', () => {
     it('identifies the correct variables using multiple custom patterns that match out-of-order', () => {
         const parsedDiff = executeFileDiff(path.join(__dirname, '../samples/nodejs'))
         const results = parseFiles(parsedDiff, { matchPatterns: {
-            js: ['myClient.variable\\(\\w*,\\s*"([^"\']*)"', 'checkVariable\\(\\w*,\\s*"([^"\']*)"']
+            js: ['myClient.variable\\(\\w*,\\s*([^,)]*)\\s*', 'checkVariable\\(\\w*,\\s*([^,)]*)\\s*']
         } })
         expect(results).to.deep.equal({
             nodejs: nodeSimpleMatchResult,

--- a/test/utils/diff/parsers/react.test.ts
+++ b/test/utils/diff/parsers/react.test.ts
@@ -16,6 +16,13 @@ describe('react', () => {
             'line': 3,
             'mode': 'add',
             'name': 'multi-line'
+        },
+        {
+            'fileName': 'test/utils/diff/sampleDiff.jsx',
+            'isUnknown': true,
+            'line': 8,
+            'mode': 'add',
+            'name': 'ALIASED_VARIABLE'
         }
     ]
     it('identifies the correct variable usages in the React sample diff', () => {

--- a/test/utils/diff/samples/custom-pattern
+++ b/test/utils/diff/samples/custom-pattern
@@ -3,12 +3,5 @@ new file mode 100644
 index 00000000..ed8ee4ab
 --- /dev/null
 +++ b/test/utils/diff/sampleDiff.jsx
-@@ -1,1 +1,8 @@
-+useVariable("simple-case", true)
-+
-+useVariable(
-+        "multi-line",
-+        true
-+    )
-+
-+useVariable(ALIASED_VARIABLE, true)
+@@ -1,1 +1,1 @@
++const var = useDVCVariable(ALIASED_VARIABLE, true)?.value


### PR DESCRIPTION
- Update readme to specify that custom match pattern must include the entire key parameter, including quotes if applicable
- Remove development section from readme
- Add isUnknown property to custom matches based on whether quotes are found