### PR TITLE
feat: update json output structure

### DIFF
--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -148,10 +148,10 @@ export default class Usages extends Base {
                 language: match.language
             }
         }
-        return Object.keys(matches).map(key => {
+        return Object.keys(matches).map((key) => {
             return {
                 key,
-                references: matches[key].map(match => formatVariableMatchToReference(match)) 
+                references: matches[key].map((match) => formatVariableMatchToReference(match)) 
             }
         })
     }

--- a/src/commands/usages/types.d.ts
+++ b/src/commands/usages/types.d.ts
@@ -1,4 +1,4 @@
-import { Range } from "../../utils/parsers/types"
+import { Range } from '../../utils/parsers/types'
 
 export type File = {
     name: string

--- a/src/commands/usages/types.d.ts
+++ b/src/commands/usages/types.d.ts
@@ -1,3 +1,5 @@
+import { Range } from "../../utils/parsers/types"
+
 export type File = {
     name: string
     lines: LineItem[]
@@ -5,5 +7,22 @@ export type File = {
 
 export type LineItem = {
     ln: number
+    content: string
+}
+
+export type JSONMatch = {
+    key: string,
+    references: VariableReference[]
+}
+
+export type VariableReference = {  
+    codeSnippet: CodeSnippet,
+    lineNumbers: Range
+    fileName: string
+    language: string
+}
+
+export type CodeSnippet = {
+    lineNumbers: Range,
     content: string
 }

--- a/src/utils/parsers/common.ts
+++ b/src/utils/parsers/common.ts
@@ -361,8 +361,8 @@ export abstract class BaseParser {
         for (const match of matches) {
             const range = this.extractUsageRange(filteredFile, match)
 
-            const bufferedStart = (range.start - buffer) < 0 ? 0 : range.start - buffer
-            const bufferedEnd = (range.end + buffer) > file.lines.length ? file.lines.length : range.end + buffer
+            const bufferedStart = Math.max(range.start - buffer, 0)
+            const bufferedEnd = Math.min(range.end + buffer, file.lines.length)
             const bufferedContent = file.lines
                 .filter((line) => range.start - buffer <= line.ln && range.end + buffer >= line.ln)
                 .map(line => line.content)

--- a/src/utils/parsers/common.ts
+++ b/src/utils/parsers/common.ts
@@ -361,6 +361,8 @@ export abstract class BaseParser {
         for (const match of matches) {
             const range = this.extractUsageRange(filteredFile, match)
 
+            const bufferedStart = (range.start - buffer) < 0 ? 0 : range.start - buffer
+            const bufferedEnd = (range.end + buffer) > file.lines.length ? file.lines.length : range.end + buffer
             const bufferedContent = file.lines
                 .filter((line) => range.start - buffer <= line.ln && range.end + buffer >= line.ln)
                 .map(line => line.content)
@@ -369,6 +371,11 @@ export abstract class BaseParser {
             result.push({
                 name: match.name,
                 line: range.start,
+                lines: range,
+                bufferedLines: {
+                    start: bufferedStart,
+                    end: bufferedEnd
+                },
                 fileName: file.name,
                 content: bufferedContent,
                 language: this.identity

--- a/src/utils/parsers/common.ts
+++ b/src/utils/parsers/common.ts
@@ -365,7 +365,7 @@ export abstract class BaseParser {
             const bufferedEnd = Math.min(range.end + buffer, file.lines.length)
             const bufferedContent = file.lines
                 .filter((line) => range.start - buffer <= line.ln && range.end + buffer >= line.ln)
-                .map(line => line.content)
+                .map((line) => line.content)
                 .join('\n')
             
             result.push({

--- a/src/utils/parsers/types.ts
+++ b/src/utils/parsers/types.ts
@@ -7,6 +7,8 @@ export type VariableMatch = {
 }
 
 export type VariableUsageMatch = VariableMatch & {
+    lines: Range
+    bufferedLines: Range
     content: string
     language: string
 }

--- a/src/utils/usages/parse.ts
+++ b/src/utils/usages/parse.ts
@@ -1,6 +1,6 @@
 import { AndroidParser, CsharpParser, GolangParser, IosParser, JavaParser,
     JavascriptParser, NodeParser, PhpParser, PythonParser, ReactParser, RubyParser } from '../parsers'
-import { ParseOptions, VariableMatch } from '../parsers/types'
+import { ParseOptions, VariableMatch, VariableUsageMatch } from '../parsers/types'
 import { CustomParser } from '../parsers/custom'
 import { File } from '../../commands/usages/types'
 
@@ -19,8 +19,8 @@ const PARSERS: Record<string, (typeof NodeParser)[]> = {
     php: [PhpParser]
 }
 
-export const parseFiles = (files: File[], options: ParseOptions = {}): Record<string, VariableMatch[]> => {
-    const resultsByLanguage: Record<string, VariableMatch[]> = {}
+export const parseFiles = (files: File[], options: ParseOptions = {}): Record<string, VariableUsageMatch[]> => {
+    const resultsByLanguage: Record<string, VariableUsageMatch[]> = {}
 
     const ALL_PARSERS = { ...PARSERS }
 

--- a/test/commands/usages.test.ts
+++ b/test/commands/usages.test.ts
@@ -10,17 +10,15 @@ DevCycle Variable Usage:
 \t- test/utils/usages/samples/nodejs.js:L4
 3. multi-line
 \t- test/utils/usages/samples/nodejs.js:L10
-4. single-comment
-\t- test/utils/usages/samples/nodejs.js:L17
-5. multi-line-comment
+4. multi-line-comment
 \t- test/utils/usages/samples/nodejs.js:L20
-6. user-object
+5. user-object
 \t- test/utils/usages/samples/nodejs.js:L23
-7. user-constructor
+6. user-constructor
 \t- test/utils/usages/samples/nodejs.js:L24
-8. multi-line-user-object
+7. multi-line-user-object
 \t- test/utils/usages/samples/nodejs.js:L25
-9. VARIABLES.ENUM_VARIABLE
+8. VARIABLES.ENUM_VARIABLE
 \t- test/utils/usages/samples/nodejs.js:L33
 `
 


### PR DESCRIPTION
# Changes

- If user inputs json output, format result into JSON in the form of: 
```
[
    {
      "key": "string",
      "references": [
        {
          "codeSnippet": {
            "lineNumbers": {
              "start": 1,
              "end": 1
            },
            "content": "string"
          },
          "lineNumbers": {
            "start": 1,
            "end": 1
          },
          "fileName": "string",
          "language": "string"
        }
      ]
    }
  ]
```