### PR TITLE
Map file extensions to language

### DIFF
--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -104,7 +104,7 @@ export default class Usages extends Base {
         
         if (flags['format'] === 'json') {
             const matchesByVariableJSON = this.formatMatchesToJSON(matchesByVariable)
-            this.log(JSON.stringify(matchesByVariableJSON))
+            this.log(JSON.stringify(matchesByVariableJSON, null, 2))
         } else {
             this.formatConsoleOutput(matchesByVariable)
         }

--- a/src/utils/parsers/BaseParser.ts
+++ b/src/utils/parsers/BaseParser.ts
@@ -1,6 +1,7 @@
 import parse from 'parse-diff'
 import { ParseOptions, VariableDiffMatch, Range, VariableUsageMatch } from './types'
 import * as usage from '../../commands/usages/types'
+import { LANGUAGE_MAP } from '../parsers'
 
 type MatchWithRange = {
     // Variable name
@@ -293,6 +294,7 @@ export abstract class BaseParser {
     parseFile(file: usage.File): VariableUsageMatch[] {
         const buffer = 3
         const results: VariableUsageMatch[] = []
+        const fileExtension = file.name?.split('.').pop() ?? ''
 
         const parsedLines = file.lines.map((line) => new ParsedLine(line))
         const { lines, content } = this.filterAndReduceLines(parsedLines)
@@ -323,7 +325,7 @@ export abstract class BaseParser {
                 },
                 fileName: file.name,
                 content: bufferedContent,
-                language: this.identity,
+                language: LANGUAGE_MAP[fileExtension],
                 ...(match.isUnknown ? { isUnknown: true } : {})
             })
         })

--- a/src/utils/parsers/index.ts
+++ b/src/utils/parsers/index.ts
@@ -36,3 +36,18 @@ export const PARSERS: Record<string, (typeof NodeParser)[]> = {
     swift: [IosParser],
     php: [PhpParser]
 }
+
+export const LANGUAGE_MAP: Record<string, string> = {
+    js: 'javascript',
+    jsx: 'jsx',
+    ts: 'typescript',
+    tsx: 'tsx',
+    java: 'java',
+    kt: 'kotlin',
+    cs: 'csharp',
+    rb: 'ruby',
+    py: 'python',
+    go: 'go',
+    swift: 'swift',
+    php: 'php'
+}


### PR DESCRIPTION
Using the parser identity to determine the language does not work in the CustomParser case (returns 'custom' as the language). Instead, map the file extension to the language 