### PR TITLE
DVC-3490 Separate repo config from user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The CLI can be customized in several ways using command-line args or by creating
 * [Authentication](#authentication)
 * [Usage](#usage)
 * [Commands](#commands)
-* [Configuration](#configuration)
+* [Command Topics](#command-topics)
+* [Repo Configuration](#repo-configuration)
 <!-- tocstop -->
 # Setup
 ## Install the CLI:
@@ -32,8 +33,7 @@ This process will open browser windows to interact with the DevCycle universal l
 To switch organizations once logged in, the [org command](docs/org.md) can be used.
 ## Using Client Credentials
 ### Credentials File
-Create a subdirectory inside the directory where you're running the CLI called `.devcycle`, then inside that directory
-create an `auth.yml` file with the following contents:
+Check the [oclif docs](https://oclif.io/docs/config) to find where the default `configDir` is located. Within that directory, create a `devcycle` directory, if it does not already exist. Inside of the `devcycle` directory, create an `auth.yml` file with the following contents:
 
 ```yaml
 clientCredentials:
@@ -41,13 +41,13 @@ clientCredentials:
   client_secret: <your client secret>
 ```
 This file should **not** be checked in to version control.
+## Project Selection
 
-You also need to specify the default project ID for the CLI to use. 
+You also need to specify the default project ID for the CLI to use.
 
-This can be set using the [project select command](docs/project.md#dvc-projects-select) or by manually updating the [configuration](#configuration) file:
-```yaml
-project: <your project id>
-```
+If there is a repo configuration file, the [`dvc diff`](docs/diff.md) and [`dvc usages`](docs/usages.md) commands will use the project defined there.
+
+Otherwise, this is chosen during login or set using the [project select command](docs/project.md#dvc-projects-select)
 
 ### Environment Variables
 Set the following environment variables:
@@ -60,7 +60,9 @@ $ export DVC_PROJECT_KEY=<your project key>
 The CLI can be run with the following arguments:
 ```sh-session
 $ dvc --client-id=<your client id> --client-secret=<your client secret> --project=<your project key>
-
+```
+### Github Action
+The Devcycle Github actions are configured with auth information through the `project-key`, `client-id` and `client-secret` configuration parameters. This is passed to the CLI via command line arguments.
 # Usage
 <!-- usage -->
 ```sh-session
@@ -77,351 +79,26 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`dvc diff [DIFF-PATTERN]`](#dvc-diff-diff-pattern)
-* [`dvc features get`](#dvc-features-get)
-* [`dvc features list`](#dvc-features-list)
-* [`dvc help [COMMAND]`](#dvc-help-command)
-* [`dvc login sso`](#dvc-login-sso)
-* [`dvc logout`](#dvc-logout)
-* [`dvc org`](#dvc-org)
-* [`dvc projects select`](#dvc-projects-select)
-* [`dvc usages`](#dvc-usages)
-* [`dvc variables create`](#dvc-variables-create)
-* [`dvc variables get`](#dvc-variables-get)
-* [`dvc variables list`](#dvc-variables-list)
-* [`dvc variables update`](#dvc-variables-update)
+# Command Topics
+
+* [`dvc diff`](docs/diff.md) - Print a diff of DevCycle variable usage between two versions of your code.
+* [`dvc features`](docs/features.md) - Access or modify Features with the Management API
+* [`dvc help`](docs/help.md) - Display help for dvc.
+* [`dvc login`](docs/login.md) - Log in to DevCycle
+* [`dvc logout`](docs/logout.md) - Discards any auth configuration that has been stored in the auth configuration file.
+* [`dvc org`](docs/org.md) - Switch organizations
+* [`dvc projects`](docs/projects.md) - Access Projects with the Management API
+* [`dvc usages`](docs/usages.md) - Print all DevCycle variable usages in the current version of your code.
+* [`dvc variables`](docs/variables.md) - Access or modify Variables with the Management API
 
-## `dvc diff [DIFF-PATTERN]`
-
-Print a diff of DevCycle variable usage between two versions of your code.
-
-```
-USAGE
-  $ dvc diff [DIFF-PATTERN] [--config-path <value>] [--auth-path <value>] [--client-id <value>]
-    [--client-secret <value>] [--project <value>] [--no-api] [-f <value>] [--client-name <value>] [--match-pattern
-    <value>] [--var-alias <value>] [--format console|markdown] [--show-regex]
-
-ARGUMENTS
-  DIFF-PATTERN  A "git diff"-compatible diff pattern, eg. "branch1 branch2"
-
-FLAGS
-  -f, --file=<value>          File path of existing diff file to inspect.
-  --client-name=<value>...    Name(s) of the DevCycle client variable to match on. Accepts multiple values.
-  --format=<option>           [default: console] Format to use when outputting the diff results.
-                              <options: console|markdown>
-  --match-pattern=<value>...  Additional full Regex pattern to use to match variable usages in your code. Should contain
-                              exactly one capture group which matches on the key of the variable. Must specify the file
-                              extension to override the pattern for, eg. "--match-pattern js=<YOUR PATTERN>"
-  --show-regex                Output the regex pattern used to find variable usage
-  --var-alias=<value>...      Aliases to use when identifying variables in your code. Should contain a code reference
-                              mapped to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Print a diff of DevCycle variable usage between two versions of your code.
-
-EXAMPLES
-  $ dvc diff
-
-  $ dvc diff --match-pattern javascript="dvcClient\.variable\(\s*["']([^"']*)["']"
-```
-
-_See code: [dist/commands/diff/index.ts](https://github.com/DevCycleHQ/cli/blob/v3.0.3/dist/commands/diff/index.ts)_
-
-## `dvc features get`
-
-Retrieve Features from the management API
-
-```
-USAGE
-  $ dvc features get [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--keys <value>]
-
-FLAGS
-  --keys=<value>  Comma-separated list of feature keys to fetch details for
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Retrieve Features from the management API
-
-EXAMPLES
-  $ dvc features get
-
-  $ dvc features get --keys=feature-one,feature-two
-```
-
-## `dvc features list`
-
-```
-USAGE
-  $ dvc features list [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-```
-
-## `dvc help [COMMAND]`
-
-Display help for dvc.
-
-```
-USAGE
-  $ dvc help [COMMAND] [-n]
-
-ARGUMENTS
-  COMMAND  Command to show help for.
-
-FLAGS
-  -n, --nested-commands  Include all nested commands in the output.
-
-DESCRIPTION
-  Display help for dvc.
-```
-
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.10/src/commands/help.ts)_
-
-## `dvc login sso`
-
-Log in through the DevCycle Universal Login. This will open a browser window
-
-```
-USAGE
-  $ dvc login sso [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Log in through the DevCycle Universal Login. This will open a browser window
-```
-
-## `dvc logout`
-
-Discards any auth configuration that has been stored in the auth configuration file.
-
-```
-USAGE
-  $ dvc logout [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Discards any auth configuration that has been stored in the auth configuration file.
-```
-
-_See code: [dist/commands/logout/index.ts](https://github.com/DevCycleHQ/cli/blob/v3.0.3/dist/commands/logout/index.ts)_
-
-## `dvc org`
-
-Select which organization to access through the API
-
-```
-USAGE
-  $ dvc org [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Select which organization to access through the API
-```
-
-_See code: [dist/commands/org/index.ts](https://github.com/DevCycleHQ/cli/blob/v3.0.3/dist/commands/org/index.ts)_
-
-## `dvc projects select`
-
-```
-USAGE
-  $ dvc projects select [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-```
-
-## `dvc usages`
-
-Print all DevCycle variable usages in the current version of your code.
-
-```
-USAGE
-  $ dvc usages [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--include <value>] [--exclude <value>] [--client-name <value>] [--match-pattern
-    <value>] [--var-alias <value>] [--format console|json] [--show-regex]
-
-FLAGS
-  --client-name=<value>...    Name(s) of the DevCycle client variable to match on. Accepts multiple values.
-  --exclude=<value>...        Files to exclude when scanning for usages. By default all files are included. Accepts
-                              multiple glob patterns.
-  --format=<option>           [default: console] Format to use when outputting the usage results.
-                              <options: console|json>
-  --include=<value>...        Files to include when scanning for usages. By default all files are included. Accepts
-                              multiple glob patterns.
-  --match-pattern=<value>...  Additional full Regex pattern to use to match variable usages in your code. Should contain
-                              exactly one capture group which matches on the key of the variable. Must specify the file
-                              extension to override the pattern for, eg. "--match-pattern js=<YOUR PATTERN>"
-  --show-regex                Output the regex pattern used to find variable usage
-  --var-alias=<value>...      Aliases to use when identifying variables in your code. Should contain a code reference
-                              mapped to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Print all DevCycle variable usages in the current version of your code.
-
-EXAMPLES
-  $ dvc usages
-
-  $ dvc usages --match-pattern javascript="dvcClient\.variable\(\s*["']([^"']*)["']"
-```
-
-_See code: [dist/commands/usages/index.ts](https://github.com/DevCycleHQ/cli/blob/v3.0.3/dist/commands/usages/index.ts)_
-
-## `dvc variables create`
-
-Create a new Variable for an existing Feature.
-
-```
-USAGE
-  $ dvc variables create [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Create a new Variable for an existing Feature.
-```
-
-## `dvc variables get`
-
-```
-USAGE
-  $ dvc variables get [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--keys <value>]
-
-FLAGS
-  --keys=<value>  Comma-separated list of variable keys to fetch details for
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-```
-
-## `dvc variables list`
-
-```
-USAGE
-  $ dvc variables list [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-```
-
-## `dvc variables update`
-
-Update a Variable.
-
-```
-USAGE
-  $ dvc variables update [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
-
-GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
-
-DESCRIPTION
-  Update a Variable.
-```
 <!-- commandsstop -->
-# Configuration
-Many of the options available as command-line args can also be specified using a configuration file. The default
-location for this file is `<REPO ROOT>/.devcycle/config.yml`. It is also assumed that the CLI commands are run from the
-root of the repository.
+# Repo Configuration
+It is assumed that the [`dvc diff`](docs/diff.md) and [`dvc usages`](docs/usages.md) commands are run from the root of the repository
 
-This location can be overridden using the `--config-path` flag.
+Many of the options available as command-line args for these commands can also be specified using a repo configuration file. The default
+location for this file is `<REPO ROOT>/.devcycle/config.yml`.
+
+This location can be overridden using the `--repo-config-path` flag.
 
 The configuration file format is documented below:
 
@@ -448,8 +125,6 @@ codeInsights:
     ## an array of file glob patterns to exclude from usage scan
     excludeFiles:
         - 'dist/*'
-## the default project key to use for commands that interact with the DevCycle API.
-project: my-project
 ```
 
 #Development

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -11,9 +11,9 @@ Print a diff of DevCycle variable usage between two versions of your code.
 
 ```
 USAGE
-  $ dvc diff [DIFF-PATTERN] [--config-path <value>] [--auth-path <value>] [--client-id <value>]
-    [--client-secret <value>] [--project <value>] [--no-api] [-f <value>] [--client-name <value>] [--match-pattern
-    <value>] [--var-alias <value>] [--format console|markdown] [--show-regex]
+  $ dvc diff [DIFF-PATTERN] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>]
+    [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [-f <value>] [--client-name <value>]
+    [--match-pattern <value>] [--var-alias <value>] [--format console|markdown] [--show-regex]
 
 ARGUMENTS
   DIFF-PATTERN  A "git diff"-compatible diff pattern, eg. "branch1 branch2"
@@ -31,13 +31,14 @@ FLAGS
                               mapped to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Print a diff of DevCycle variable usage between two versions of your code.

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,20 +12,21 @@ Retrieve Features from the management API
 
 ```
 USAGE
-  $ dvc features get [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--keys <value>]
+  $ dvc features get [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--keys <value>]
 
 FLAGS
   --keys=<value>  Comma-separated list of feature keys to fetch details for
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Retrieve Features from the management API
@@ -40,15 +41,16 @@ EXAMPLES
 
 ```
 USAGE
-  $ dvc features list [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc features list [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```

--- a/docs/login.md
+++ b/docs/login.md
@@ -11,17 +11,18 @@ Log in through the DevCycle Universal Login. This will open a browser window
 
 ```
 USAGE
-  $ dvc login sso [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc login sso [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Log in through the DevCycle Universal Login. This will open a browser window

--- a/docs/logout.md
+++ b/docs/logout.md
@@ -11,17 +11,18 @@ Discards any auth configuration that has been stored in the auth configuration f
 
 ```
 USAGE
-  $ dvc logout [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc logout [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Discards any auth configuration that has been stored in the auth configuration file.

--- a/docs/org.md
+++ b/docs/org.md
@@ -11,17 +11,18 @@ Select which organization to access through the API
 
 ```
 USAGE
-  $ dvc org [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc org [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Select which organization to access through the API

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -9,15 +9,16 @@ Access Projects with the Management API
 
 ```
 USAGE
-  $ dvc projects select [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc projects select [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```

--- a/docs/usages.md
+++ b/docs/usages.md
@@ -11,9 +11,9 @@ Print all DevCycle variable usages in the current version of your code.
 
 ```
 USAGE
-  $ dvc usages [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--include <value>] [--exclude <value>] [--client-name <value>] [--match-pattern
-    <value>] [--var-alias <value>] [--format console|json] [--show-regex]
+  $ dvc usages [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--include <value>] [--exclude <value>]
+    [--client-name <value>] [--match-pattern <value>] [--var-alias <value>] [--format console|json] [--show-regex]
 
 FLAGS
   --client-name=<value>...    Name(s) of the DevCycle client variable to match on. Accepts multiple values.
@@ -31,13 +31,14 @@ FLAGS
                               mapped to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Print all DevCycle variable usages in the current version of your code.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -14,17 +14,18 @@ Create a new Variable for an existing Feature.
 
 ```
 USAGE
-  $ dvc variables create [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc variables create [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Create a new Variable for an existing Feature.
@@ -34,37 +35,39 @@ DESCRIPTION
 
 ```
 USAGE
-  $ dvc variables get [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api] [--keys <value>]
+  $ dvc variables get [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--keys <value>]
 
 FLAGS
   --keys=<value>  Comma-separated list of variable keys to fetch details for
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```
 
 ## `dvc variables list`
 
 ```
 USAGE
-  $ dvc variables list [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc variables list [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```
 
 ## `dvc variables update`
@@ -73,17 +76,18 @@ Update a Variable.
 
 ```
 USAGE
-  $ dvc variables update [--config-path <value>] [--auth-path <value>] [--client-id <value>] [--client-secret <value>]
-    [--project <value>] [--no-api]
+  $ dvc variables update [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api]
 
 GLOBAL FLAGS
-  --auth-path=<value>      Override the default location to look for an auth.yml file
-  --client-id=<value>      Client ID to use for DevCycle API Authorization
-  --client-secret=<value>  Client Secret to use for DevCycle API Authorization
-  --config-path=<value>    Override the default location to look for a config.yml file
-  --no-api                 Disable API-based enhancements for commands where authorization is optional. Suppresses
-                           warnings about missing credentials.
-  --project=<value>        Project key to use for the DevCycle API requests
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
   Update a Variable.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "oclif": {
     "bin": "dvc",
-    "dirname": "oex",
+    "dirname": "devcycle",
     "commands": "./dist/commands",
     "plugins": [
       "@oclif/plugin-help"
@@ -86,9 +86,9 @@
     "lint": "eslint . --ext .ts --config .eslintrc",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
-    "prepack": "yarn build && oclif manifest && oclif readme",
+    "prepack": "yarn build && oclif manifest && oclif readme --multi",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif readme && git add README.md"
+    "version": "oclif readme --multi && git add README.md"
   },
   "engines": {
     "node": ">=14.18.0 <17.0.0"

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -44,6 +44,7 @@ type MatchesByTypeEnriched = {
 export default class Diff extends Base {
     static hidden = false
     authSuggested = true
+    runsInRepo = true
 
     static description = 'Print a diff of DevCycle variable usage between two versions of your code.'
     static examples = [
@@ -88,12 +89,12 @@ export default class Diff extends Base {
         const parsedDiff = flags.file ? executeFileDiff(flags.file) : executeDiff(args['diff-pattern'])
 
         const matchesBySdk = parseFiles(parsedDiff, {
-            clientNames: getClientNames(flags, this.configFromFile),
-            matchPatterns: getMatchPatterns(flags, this.configFromFile),
+            clientNames: getClientNames(flags, this.repoConfig),
+            matchPatterns: getMatchPatterns(flags, this.repoConfig),
             printPatterns: showRegex(flags)
         })
 
-        const variableAliases = getVariableAliases(flags, this.configFromFile)
+        const variableAliases = getVariableAliases(flags, this.repoConfig)
 
         const matchesByType = this.getMatchesByType(matchesBySdk, variableAliases)
 

--- a/src/commands/login/sso.ts
+++ b/src/commands/login/sso.ts
@@ -26,7 +26,7 @@ export default class Login extends Base {
 
         const projects = await fetchProjects(token)
         const selectedProject = await promptForProject(projects)
-        await this.updateConfig({ project: selectedProject.key })
+        await this.updateUserConfig({ project: selectedProject.key })
 
         console.log('')
         successMessage('Successfully logged in to DevCycle')

--- a/src/commands/org/index.ts
+++ b/src/commands/org/index.ts
@@ -24,7 +24,7 @@ export default class SelectOrganization extends Base {
 
         const projects = await fetchProjects(token)
         const selectedProject = await promptForProject(projects)
-        await this.updateConfig({ project:selectedProject.key })
+        await this.updateUserConfig({ project:selectedProject.key })
     }
 
     private async selectOrganization(organization:Organization) {

--- a/src/commands/projects/select.ts
+++ b/src/commands/projects/select.ts
@@ -9,6 +9,6 @@ export default class ListVariables extends Base {
     public async run(): Promise<void> {
         const projects = await fetchProjects(this.token)
         const selected = await promptForProject(projects)
-        await this.updateConfig({ project:selected.key })
+        await this.updateUserConfig({ project:selected.key })
     }
 }

--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -13,6 +13,7 @@ import { VariableMatch, VariableUsageMatch } from '../../utils/parsers/types'
 
 export default class Usages extends Base {
     static hidden = false
+    runsInRepo = true
 
     static description = 'Print all DevCycle variable usages in the current version of your code.'
     static examples = [
@@ -48,7 +49,7 @@ export default class Usages extends Base {
 
     public async run(): Promise<void> {
         const { flags } = await this.parse(Usages)
-        const codeInsightsConfig = this.configFromFile?.codeInsights || {}
+        const codeInsightsConfig = this.repoConfig?.codeInsights || {}
 
         this.useMarkdown = flags.format === 'markdown'
 
@@ -93,12 +94,12 @@ export default class Usages extends Base {
         }
 
         const matchesBySdk = parseFiles(files, {
-            clientNames: getClientNames(flags, this.configFromFile),
-            matchPatterns: getMatchPatterns(flags, this.configFromFile),
+            clientNames: getClientNames(flags, this.repoConfig),
+            matchPatterns: getMatchPatterns(flags, this.repoConfig),
             printPatterns: showRegex(flags)
         })
 
-        const variableAliases = getVariableAliases(flags, this.configFromFile)
+        const variableAliases = getVariableAliases(flags, this.repoConfig)
         
         const matchesByVariable = this.getMatchesByVariable(matchesBySdk, variableAliases)
         

--- a/src/flags/client-name/index.ts
+++ b/src/flags/client-name/index.ts
@@ -1,11 +1,11 @@
 import { Flags } from '@oclif/core'
-import { ConfigFromFile } from '../../types'
+import { RepoConfigFromFile } from '../../types'
 
 export default Flags.string({
     description: 'Name(s) of the DevCycle client variable to match on. Accepts multiple values.', multiple: true
 })
 
-export function getClientNames(flags: Record<string, any>, config: ConfigFromFile | null) {
+export function getClientNames(flags: Record<string, any>, config: RepoConfigFromFile | null) {
     const clientNamesFromConfig = config?.codeInsights?.clientNames || []
 
     return [...clientNamesFromConfig, ...(flags['client-name'] || [])]

--- a/src/flags/match-pattern/index.ts
+++ b/src/flags/match-pattern/index.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { ConfigFromFile } from '../../types'
+import { RepoConfigFromFile } from '../../types'
 
 export default Flags.string({
     description: 'Additional full Regex pattern to use to match variable usages in your code.' +
@@ -8,7 +8,7 @@ export default Flags.string({
     multiple: true
 })
 
-export function getMatchPatterns(flags: Record<string, any>, config: ConfigFromFile | null) {
+export function getMatchPatterns(flags: Record<string, any>, config: RepoConfigFromFile | null) {
     const matchPatternsFromConfig = config?.codeInsights?.matchPatterns || {}
 
     return (flags['match-pattern'] || []).reduce((map: Record<string, string>, value: string) => {

--- a/src/flags/var-alias/index.ts
+++ b/src/flags/var-alias/index.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { ConfigFromFile } from '../../types'
+import { RepoConfigFromFile } from '../../types'
 
 export default Flags.string({
     description: 'Aliases to use when identifying variables in your code.' +
@@ -8,7 +8,7 @@ export default Flags.string({
     multiple: true
 })
 
-export function getVariableAliases(flags: Record<string, any>, config: ConfigFromFile | null) {
+export function getVariableAliases(flags: Record<string, any>, config: RepoConfigFromFile | null) {
     const variableAliasesFromConfig = config?.codeInsights?.variableAliases || {}
 
     return (flags['var-alias'] || []).reduce((map: Record<string, string>, value: string) => {

--- a/src/types/configFile.ts
+++ b/src/types/configFile.ts
@@ -88,15 +88,21 @@ class CodeInsights {
     excludeFiles?: string[]
 }
 
-export class ConfigFromFile {
+export class UserConfigFromFile {
+    @IsString()
+    @IsOptional()
+    project?: string
+}
+
+export class RepoConfigFromFile {
+    @IsString()
+    @IsOptional()
+    project?: string
+    
     @Type(() => CodeInsights)
     @IsOptional()
     @ValidateNested()
     codeInsights?: CodeInsights
-
-    @IsString()
-    @IsOptional()
-    project?: string
 }
 
 export class AuthFromFile {

--- a/src/ui/output.ts
+++ b/src/ui/output.ts
@@ -4,6 +4,6 @@ export function successMessage(message:string):void {
     console.log(chalk.green(`✅ ${message}`))
 }
 
-export function showResults(results:unknown) {
+export function showResults(results:unknown):void {
     console.log(JSON.stringify(results, null, 2))
 }

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -213,7 +213,7 @@ describe('diff', () => {
         .stdout()
         .command(['diff', '--file',
             './test/utils/diff/samples/e2e',
-            '--config-path', './test/commands/fixtures/customMatcherConfig.yml', '--no-api'])
+            '--repo-config-path', './test/commands/fixtures/customMatcherConfig.yml', '--no-api'])
         .it('runs against a test file with a custom matcher specified in a config file',
             (ctx) => {
                 expect(ctx.stdout).to.equal(customExpected)
@@ -312,7 +312,7 @@ describe('diff', () => {
         .stdout()
         .command(['diff', '--file',
             './test/utils/diff/samples/aliases/aliased', '--no-api',
-            '--config-path', './test/commands/fixtures/variableAliasConfig.yml'
+            '--repo-config-path', './test/commands/fixtures/variableAliasConfig.yml'
         ])
         .it('identifies aliased variables specified in config file',
             (ctx) => {


### PR DESCRIPTION
User configuration should not be stored in the repo, so we need
separate configuration files to handle repo-configuration that the
diff and usages commands rely on from cli user configuration and
session data.