### PR TITLE
Fix typo in example

### DIFF
--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -50,7 +50,7 @@ export default class Diff extends Base {
     static examples = [
         '<%= config.bin %> <%= command.id %>',
         '<%= config.bin %> <%= command.id %> ' +
-        '--match-pattern javascript="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
+        '--match-pattern js="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
     ]
 
     static flags = {

--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -19,7 +19,7 @@ export default class Usages extends Base {
     static examples = [
         '<%= config.bin %> <%= command.id %>',
         '<%= config.bin %> <%= command.id %> ' +
-        '--match-pattern javascript="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
+        '--match-pattern js="dvcClient\\.variable\\(\\s*["\']([^"\']*)["\']"',
     ]
 
     static flags = {


### PR DESCRIPTION
`match-pattern` flag should be used with a file extension. Replace 'javascript' with correct 'js' extension.