### PR TITLE
Cleanup: if api is unavailable prompt user for variable key

### DIFF
--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -3,17 +3,17 @@
 
 Replace a DevCycle variable with a static value in the current version of your code. Currently only JavaScript is supported.
 
-* [`dvc cleanup KEY`](#dvc-cleanup-key)
+* [`dvc cleanup [KEY]`](#dvc-cleanup-key)
 
-## `dvc cleanup KEY`
+## `dvc cleanup [KEY]`
 
 Replace a DevCycle variable with a static value in the current version of your code. Currently only JavaScript is supported.
 
 ```
 USAGE
-  $ dvc cleanup [KEY] --value <value> --type String|Boolean|Number|JSON [--config-path <value>] [--auth-path
-    <value>] [--repo-config-path <value>] [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api]
-    [--include <value>] [--exclude <value>] [--output console|file] [--var-alias <value>]
+  $ dvc cleanup [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--value <value>] [--type
+    String|Boolean|Number|JSON] [--include <value>] [--exclude <value>] [--output console|file] [--var-alias <value>]
 
 ARGUMENTS
   KEY  Key of variable to replace.
@@ -26,10 +26,10 @@ FLAGS
   --output=<option>       [default: file] Where the refactored code will be output. By default it overwrites the source
                           file.
                           <options: console|file>
-  --type=<option>         (required) The type of the value that will be replacing the variable. Valid values include:
-                          String, Boolean, Number, JSON
+  --type=<option>         The type of the value that will be replacing the variable. Valid values include: String,
+                          Boolean, Number, JSON
                           <options: String|Boolean|Number|JSON>
-  --value=<value>         (required) Value to use in place of variable.
+  --value=<value>         Value to use in place of variable.
   --var-alias=<value>...  Aliases to use when identifying variables in your code. Should contain a code reference mapped
                           to a DevCycle variable key, eg. "--var-alias "VARIABLES.ENABLE_V1=enable-v1"
 
@@ -48,9 +48,11 @@ DESCRIPTION
   supported.
 
 EXAMPLES
+  $ dvc cleanup
+
   $ dvc cleanup my-variable-key --value true --type Boolean
 
   $ dvc cleanup some-var --value "My Custom Name" --type String
 ```
 
-_See code: [dist/commands/cleanup/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/cleanup/index.ts)_
+_See code: [dist/commands/cleanup/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/cleanup/index.ts)_

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -49,4 +49,4 @@ EXAMPLES
   $ dvc diff --match-pattern js="dvcClient\.variable\(\s*["']([^"']*)["']"
 ```
 
-_See code: [dist/commands/diff/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/diff/index.ts)_
+_See code: [dist/commands/diff/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/diff/index.ts)_

--- a/docs/logout.md
+++ b/docs/logout.md
@@ -28,4 +28,4 @@ DESCRIPTION
   Discards any auth configuration that has been stored in the auth configuration file.
 ```
 
-_See code: [dist/commands/logout/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/logout/index.ts)_
+_See code: [dist/commands/logout/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/logout/index.ts)_

--- a/docs/org.md
+++ b/docs/org.md
@@ -28,4 +28,4 @@ DESCRIPTION
   Select which organization to access through the API
 ```
 
-_See code: [dist/commands/org/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/org/index.ts)_
+_See code: [dist/commands/org/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/org/index.ts)_

--- a/docs/status.md
+++ b/docs/status.md
@@ -28,4 +28,4 @@ DESCRIPTION
   Print CLI version information, configuration file locations and auth status.
 ```
 
-_See code: [dist/commands/status/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/status/index.ts)_
+_See code: [dist/commands/status/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/status/index.ts)_

--- a/docs/usages.md
+++ b/docs/usages.md
@@ -49,4 +49,4 @@ EXAMPLES
   $ dvc usages --match-pattern js="dvcClient\.variable\(\s*["']([^"']*)["']"
 ```
 
-_See code: [dist/commands/usages/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.0.0/dist/commands/usages/index.ts)_
+_See code: [dist/commands/usages/index.ts](https://github.com/DevCycleHQ/cli/blob/v4.1.0/dist/commands/usages/index.ts)_

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -24,6 +24,11 @@ export const variablePrompt = {
     choices: variableChoices
 }
 
+export const variablePromptNoApi = {
+    name: 'variable',
+    message: 'Please enter a variable key:'
+}
+
 export const variableTypePrompt = {
     name: 'type',
     message: 'The type of variable',
@@ -33,6 +38,5 @@ export const variableTypePrompt = {
 
 export const variableValuePrompt = {
     name: 'value',
-    message: 'Variable value',
-    type: 'string'
+    message: 'Variable value'
 }


### PR DESCRIPTION
If variable.key is not set, and variable list prompt fails, prompt user to enter a variable key rather than throwing an error