### PR TITLE
[fix] When selecting a project, always update user config

### DIFF
--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -41,9 +41,8 @@ export default abstract class AuthCommand extends Base {
     public async saveProject(project:Project) {
         if (this.repoConfig) {
             await this.updateRepoConfig({ project: project.key })
-        } else {
-            await this.updateUserConfig({ project: project.key })
         }
+        await this.updateUserConfig({ project: project.key })
     }
 
     public async retrieveProjectFromConfig(projects:Project[]): Promise<Project | null> {


### PR DESCRIPTION
Currently when selecting a project within a repo only the repo config will be updated. This results in a 404 when running a command that does not require repo context (ie. `features list`), because the stored project does not belong to the authenticated org