### PR TITLE
[feat] Add support for parsing dart files

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -70,6 +70,7 @@ export default abstract class Base extends Command {
     authPath = path.join(this.config.configDir, 'auth.yml')
     configPath = path.join(this.config.configDir, 'user.yml')
     repoConfigPath = '.devcycle/config.yml'
+    noApi = false
     caller = 'cli'
 
     // Override to true in commands that must be authorized in order to function
@@ -180,6 +181,10 @@ export default abstract class Base extends Command {
 
         if (flags['repo-config-path']) {
             this.repoConfigPath = flags['repo-config-path']
+        }
+
+        if (flags['no-api']) {
+            this.noApi = flags['no-api']
         }
 
         if (flags['caller']) {

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -106,7 +106,7 @@ export default class Diff extends Base {
     }
 
     private useApi() {
-        return this.hasToken() && this.projectKey !== ''
+        return this.hasToken() && this.projectKey !== '' && this.noApi !== true
     }
 
     private getMatchesByType(

--- a/src/utils/parsers/dart/index.ts
+++ b/src/utils/parsers/dart/index.ts
@@ -1,0 +1,15 @@
+import { BaseParser } from '../BaseParser'
+
+const variableNameCapturePattern = /([^,)]*)/
+const defaultValueCapturePattern = /(?:[^),]*|{[^}]*})/
+
+export class DartParser extends BaseParser {
+    identity = 'dart'
+    variableMethodPattern = /\??\.variable\(\s*/
+    orderedParameterPatterns = [
+        variableNameCapturePattern,
+        defaultValueCapturePattern
+    ]
+
+    commentCharacters = ['//', '/*']
+}

--- a/src/utils/parsers/index.ts
+++ b/src/utils/parsers/index.ts
@@ -9,6 +9,7 @@ import { PythonParser } from './python'
 import { GolangParser } from './golang'
 import { IosParser } from './ios'
 import { PhpParser } from './php'
+import { DartParser } from './dart'
 
 export * from './android'
 export * from './csharp'
@@ -21,6 +22,7 @@ export * from './php'
 export * from './python'
 export * from './react'
 export * from './ruby'
+export * from './dart'
 
 export const PARSERS: Record<string, (typeof NodeParser)[]> = {
     js: [NodeParser, ReactParser, JavascriptParser],
@@ -34,7 +36,8 @@ export const PARSERS: Record<string, (typeof NodeParser)[]> = {
     py: [PythonParser],
     go: [GolangParser],
     swift: [IosParser],
-    php: [PhpParser]
+    php: [PhpParser],
+    dart: [DartParser]
 }
 
 export const LANGUAGE_MAP: Record<string, string> = {
@@ -49,5 +52,6 @@ export const LANGUAGE_MAP: Record<string, string> = {
     py: 'python',
     go: 'go',
     swift: 'swift',
-    php: 'php'
+    php: 'php',
+    dart: 'dart'
 }

--- a/test-utils/fixtures/diff/dart
+++ b/test-utils/fixtures/diff/dart
@@ -1,0 +1,14 @@
+diff --git a/test-utils/fixtures/diff/sampleDiff.dart b/test-utils/fixtures/diff/sampleDiff.dart
+new file mode 100644
+index 00000000..ed8ee4ab
+--- /dev/null
++++ b/test-utils/fixtures/diff/sampleDiff.dart
+@@ -1,1 +1,8 @@
++dvcClient.variable('simple-case', true)
++
++dvcClient.variable(
++        'multi-line',
++        'string'
++    )
++
++dvcClient.variable('default-value-object', { key: "value", foo: "bar" })

--- a/test-utils/fixtures/usages/sample.dart
+++ b/test-utils/fixtures/usages/sample.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:devcycle_flutter_client_sdk/devcycle_flutter_client_sdk.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _logger = Logger();
+  String _platformVersion = 'Unknown';
+  String _displayValue = '';
+  String _variableValue = '';
+  bool _booleanValue = false;
+  num _integerValue = 0;
+  num _doubleValue = 0.0;
+  var _jsonArrayValue = '';
+  var _jsonObjectValue = '';
+
+  var encodedJsonArray = '''
+  [
+    {"score": 40},
+    {"score": 80}
+  ]
+''';
+  var encodedJsonObject = '''
+  {
+    "score1": 40,
+    "score2": 80
+  }
+''';
+
+  final _dvcClient = DVCClientBuilder()
+      .sdkKey('YOUR_DVC_MOBILE_SDK_KEY')
+      .user(DVCUserBuilder().userId('123').build())
+      .options(DVCOptionsBuilder().logLevel(LogLevel.debug).build())
+      .build();
+
+  @override
+  void initState() {
+    super.initState();
+    initPlatformState();
+    initVariable();
+  }
+
+  // Platform messages are asynchronous, so we initialize in an async method.
+  Future<void> initPlatformState() async {
+    String platformVersion;
+    // Platform messages may fail, so we use a try/catch PlatformException.
+    // We also handle the message potentially returning null.
+    try {
+      platformVersion =
+          await _dvcClient.getPlatformVersion() ?? 'Unknown platform version';
+    } on PlatformException {
+      platformVersion = 'Failed to get platform version.';
+    }
+
+    // If the widget was removed from the tree while the asynchronous platform
+    // message was in flight, we want to discard the reply rather than calling
+    // setState to update our non-existent appearance.
+    if (!mounted) return;
+
+    setState(() {
+      _platformVersion = platformVersion;
+    });
+  }
+
+  Future<void> initVariable() async {
+    final variable =
+        await _dvcClient.variable('string-variable', 'Default Value');
+    setState(() {
+      _variableValue = variable?.value;
+    });
+    variable?.onUpdate((updatedValue) {
+      setState(() {
+        _variableValue = updatedValue;
+      });
+    });
+
+    final booleanVariable =
+        await _dvcClient.variable('boolean-variable', false);
+    setState(() {
+      _booleanValue = booleanVariable?.value;
+    });
+    booleanVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _booleanValue = updatedValue;
+      });
+    });
+
+    final integerVariable = await _dvcClient.variable('integer-variable', 188);
+    setState(() {
+      _integerValue = integerVariable?.value;
+    });
+    integerVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _integerValue = updatedValue;
+      });
+    });
+
+    final doubleVariable = await _dvcClient.variable('decimal-variable', 1.88);
+    setState(() {
+      _doubleValue = doubleVariable?.value;
+    });
+    doubleVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _doubleValue = updatedValue;
+      });
+    });
+
+    final jsonArrayVariable = await _dvcClient.variable(
+      'json-array-variable',
+      jsonDecode(encodedJsonArray)
+    );
+    setState(() {
+      _jsonArrayValue = jsonEncode(jsonArrayVariable?.value);
+    });
+    jsonArrayVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _jsonArrayValue = jsonEncode(updatedValue);
+      });
+    });
+    
+    final jsonObjectVariable = await _dvcClient.variable(
+      'json-object-variable',
+      jsonDecode(encodedJsonObject)
+    );
+    setState(() {
+      _jsonObjectValue = jsonEncode(jsonObjectVariable?.value);
+    });
+    jsonObjectVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _jsonObjectValue = jsonEncode(updatedValue);
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Plugin example app'),
+        ),
+        body: Center(
+            child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text("Value: $_variableValue"),
+            Text("Value: $_booleanValue"),
+            Text("Value: $_integerValue"),
+            Text("Value: $_doubleValue"),
+            Text("Value: $_jsonArrayValue"),
+            Text("Value: $_jsonObjectValue"),
+            Text('Running on: $_platformVersion\n'),
+            Icon(
+              Icons.star,
+              color: _booleanValue ? Colors.blue[500] : Colors.red[500],
+            ),
+            _booleanValue
+                ? const Icon(
+                    Icons.sentiment_very_satisfied,
+                    color: Colors.grey,
+                  )
+                : const Icon(
+                    Icons.sentiment_very_dissatisfied,
+                    color: Colors.grey,
+                  ),
+            ElevatedButton(
+                onPressed: showAllFeatures, child: const Text('All Features')),
+            ElevatedButton(
+                onPressed: showAllVariables,
+                child: const Text('All Variables')),
+            ElevatedButton(
+                onPressed: identifyUser, child: const Text('Identify User')),
+            ElevatedButton(
+                onPressed: identifyAnonUser,
+                child: const Text('Identify Anonymous User')),
+            ElevatedButton(
+                onPressed: resetUser, child: const Text('Reset User')),
+            ElevatedButton(
+                onPressed: trackEvent, child: const Text('Track Event')),
+            ElevatedButton(
+                onPressed: flushEvents, child: const Text('FlushEvents')),
+            Text(_displayValue)
+          ],
+        )),
+      ),
+    );
+  }
+}

--- a/test/diff-parser/parsers/dart.test.ts
+++ b/test/diff-parser/parsers/dart.test.ts
@@ -1,0 +1,35 @@
+import { executeFileDiff } from '../../../src/utils/diff/fileDiff'
+import * as path from 'node:path'
+import { parseFiles } from '../../../src/utils/diff/parse'
+import { expect } from '@oclif/test'
+
+describe('dart', () => {
+    const simpleMatchResult = [
+        {
+            'fileName': 'test-utils/fixtures/diff/sampleDiff.dart',
+            'line': 1,
+            'mode': 'add',
+            'name': 'simple-case'
+        },
+        {
+            'fileName': 'test-utils/fixtures/diff/sampleDiff.dart',
+            'line': 3,
+            'mode': 'add',
+            'name': 'multi-line'
+        },
+        {
+            'fileName': 'test-utils/fixtures/diff/sampleDiff.dart',
+            'line': 8,
+            'mode': 'add',
+            'name': 'default-value-object'
+        }
+    ]
+    it('identifies the correct variable usages in the JavaScript sample diff', () => {
+        const parsedDiff = executeFileDiff(path.join(__dirname, '../../../test-utils/fixtures/diff/dart'))
+        const results = parseFiles(parsedDiff)
+
+        expect(results).to.deep.equal({
+            dart: simpleMatchResult,
+        })
+    })
+})


### PR DESCRIPTION
- Add support for parsing dart files with `dvc usages` and `dvc diff` commands
- When `no-api` flag is passed, don't call API even if project/keys are defined