### PR TITLE
fix login again command

### DIFF
--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -33,7 +33,7 @@ export class AuthConfig {
     sso?: SSOAuthConfig
 }
 
-export async function storeAccessToken(accessToken:string, authPath:string):Promise<void> {
+export function storeAccessToken(accessToken:string, authPath:string): void {
     const configDir = path.dirname(authPath)
     if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true })

--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -102,6 +102,8 @@ export default abstract class AuthCommand extends Base {
         storeAccessToken(token, this.authPath)
         if (this.repoConfig) {
             this.updateRepoConfig({ org: { id, name, display_name } })
+        } else if (this.userConfig) {
+            this.updateUserConfig({ org: { id, name, display_name } })
         }
         return token
     }

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -125,9 +125,9 @@ export default abstract class Base extends Command {
         return configParsed
     }
 
-    async updateUserConfig(
+    updateUserConfig(
         changes: Partial<UserConfigFromFile>
-    ): Promise<UserConfigFromFile | null> {
+    ): UserConfigFromFile | null {
         let config = this.loadUserConfig(this.configPath)
         if (!config) {
             const configDir = path.dirname(this.configPath)
@@ -146,9 +146,9 @@ export default abstract class Base extends Command {
         return config
     }
 
-    async updateRepoConfig(
+    updateRepoConfig(
         changes: Partial<RepoConfigFromFile>
-    ): Promise<RepoConfigFromFile | null> {
+    ): RepoConfigFromFile | null {
         let config = this.loadRepoConfig(this.repoConfigPath)
         if (!config) {
             const configDir = path.dirname(this.repoConfigPath)


### PR DESCRIPTION
- fix the `login again` command when not using `repo-level` configs by writing the `organization` choice to the `user.yml` file in the `.config/devcycle` directory.