### PR TITLE
DVC-7629 [feat]: add command to get targeting rules for a specific feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ USAGE
 * [`dvc projects`](docs/projects.md) - Access Projects with the Management API
 * [`dvc repo`](docs/repo.md) - Manage repository configuration
 * [`dvc status`](docs/status.md) - Check CLI status
+* [`dvc targeting`](docs/targeting.md) - Retrieve Targeting for a Feature from the Management API
 * [`dvc usages`](docs/usages.md) - Print all DevCycle variable usages in the current version of your code.
 * [`dvc variables`](docs/variables.md) - Access or modify Variables with the Management API
 * [`dvc variations`](docs/variations.md)

--- a/docs/targeting.md
+++ b/docs/targeting.md
@@ -1,0 +1,41 @@
+`dvc targeting`
+===============
+
+Retrieve Targeting for a Feature from the Management API
+
+* [`dvc targeting get [FEATURE]`](#dvc-targeting-get-feature)
+
+## `dvc targeting get [FEATURE]`
+
+Retrieve Targeting for a Feature from the Management API
+
+```
+USAGE
+  $ dvc targeting get [FEATURE] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>]
+    [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [-e <value>]
+
+ARGUMENTS
+  FEATURE  The Feature to get the Targeting Rules
+
+FLAGS
+  -e, --env=<value>  Environment to fetch the Feature Configuration
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Retrieve Targeting for a Feature from the Management API
+
+EXAMPLES
+  $ dvc targeting get feature-one
+
+  $ dvc targeting get feature-one environment-one
+```

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -2250,6 +2250,107 @@
       },
       "args": {}
     },
+    "targeting:get": {
+      "id": "targeting:get",
+      "description": "Retrieve Targeting for a Feature from the Management API",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %> feature-one",
+        "<%= config.bin %> <%= command.id %> feature-one environment-one"
+      ],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
+        },
+        "env": {
+          "name": "env",
+          "type": "option",
+          "char": "e",
+          "description": "Environment to fetch the Feature Configuration",
+          "required": false,
+          "multiple": false
+        }
+      },
+      "args": {
+        "feature": {
+          "name": "feature",
+          "description": "The Feature to get the Targeting Rules"
+        }
+      }
+    },
     "usages": {
       "id": "usages",
       "description": "Print all DevCycle variable usages in the current version of your code.",

--- a/src/api/targeting.ts
+++ b/src/api/targeting.ts
@@ -1,0 +1,68 @@
+import apiClient from './apiClient'
+
+enum TargetingStatus {
+    active = 'active',
+    inactive = 'inactive',
+    archived = 'archived'
+}
+
+enum RolloutType {
+    schedule = 'schedule',
+    gradual = 'gradual',
+    stepped = 'stepped'
+}
+
+enum RolloutStageType {
+    linear = 'linear',
+    discrete = 'discrete'
+}
+
+class Distribution {
+    _variation: string
+    percentage: number
+}
+
+class RolloutStage {
+    type: RolloutStageType
+    date: Date
+    percentage: number
+}
+
+class Rollout {
+    type: RolloutType
+    startPercentage?: number
+    startDate?: Date
+    stages?: RolloutStage[]
+}
+
+export class TargetingRules {
+    _id: string
+    _feature: string
+    _environment: string
+    _createdBy: string
+    status: TargetingStatus
+    name?: string
+    _audience: string
+    rollout?: Rollout
+    distribution: Distribution[]
+    createdAt: Date
+    updatedAt: Date
+}
+
+export const fetchTargetingForFeature = async (
+    token: string,
+    project_id: string,
+    feature_key: string,
+    environment_key?: string
+): Promise<TargetingRules[]> => {
+    const url = `/v1/projects/${project_id}/features/${feature_key}/configurations` +
+        `${environment_key ? `?environment=${environment_key}` : ''}`
+    const response = await apiClient.get(url, {
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: token,
+        },
+    })
+
+    return response.data
+}

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -1,0 +1,66 @@
+import { Args, Flags } from '@oclif/core'
+import inquirer from 'inquirer'
+import { fetchTargetingForFeature } from '../../api/targeting'
+import { featurePrompt } from '../../ui/prompts'
+import Base from '../base'
+
+export default class DetailedTargeting extends Base {
+    static hidden = false
+    static description = 'Retrieve Targeting for a Feature from the Management API'
+    static examples = [
+        '<%= config.bin %> <%= command.id %> feature-one',
+        '<%= config.bin %> <%= command.id %> feature-one environment-one',
+    ]
+    static flags = {
+        ...Base.flags,
+        'env': Flags.string({
+            char: 'e',
+            description: 'Environment to fetch the Feature Configuration',
+            required: false
+        })
+    }
+    static args = {
+        feature: Args.string({ description: 'The Feature to get the Targeting Rules' })
+    }
+
+    authRequired = true
+
+    public async run(): Promise<void> {
+        const { args, flags } = await this.parse(DetailedTargeting)
+
+        await this.requireProject()
+
+        let responses
+
+        const feature = args['feature']
+        const environment = flags.env
+
+        if (flags.headless && !feature) {
+            throw new Error('In headless mode, the feature is required')
+        }
+
+        if (feature) {
+            responses = { _feature: feature }
+        } else {
+            responses = await inquirer.prompt(
+                [featurePrompt],
+                {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                }
+            )
+        }
+
+        if (environment) {
+            const targetingForFeatureAndEnv = await fetchTargetingForFeature(
+                this.authToken,
+                this.projectKey,
+                responses._feature,
+                environment
+            )
+            return this.writer.showResults(targetingForFeatureAndEnv)
+        }
+        const targetingForFeature = await fetchTargetingForFeature(this.authToken, this.projectKey, responses._feature)
+        return this.writer.showResults(targetingForFeature)
+    }
+}


### PR DESCRIPTION
- Adds new command of `dvc targeting get <feature-key> --env <env-key>`
  - `--env <env-key>` can also be shorted to `-e <env-key>`
- `<feature-key>` is required, if not specified the user will be prompted to select one
- `<env-key>` is optional