### PR TITLE
DVC-7630 [feat]: add enable / disable targeting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ USAGE
 * [`dvc projects`](docs/projects.md) - Access Projects with the Management API
 * [`dvc repo`](docs/repo.md) - Manage repository configuration
 * [`dvc status`](docs/status.md) - Check CLI status
-* [`dvc targeting`](docs/targeting.md) - Retrieve Targeting for a Feature from the Management API
+* [`dvc targeting`](docs/targeting.md) - Access and Modify Targeting Rules for a Feature with the Management API.
 * [`dvc usages`](docs/usages.md) - Print all DevCycle variable usages in the current version of your code.
 * [`dvc variables`](docs/variables.md) - Access or modify Variables with the Management API
 * [`dvc variations`](docs/variations.md)

--- a/docs/targeting.md
+++ b/docs/targeting.md
@@ -1,24 +1,86 @@
 `dvc targeting`
 ===============
 
-Retrieve Targeting for a Feature from the Management API
+Access and Modify Targeting Rules for a Feature with the Management API.
 
-* [`dvc targeting get [FEATURE]`](#dvc-targeting-get-feature)
+* [`dvc targeting disable [FEATURE] [ENVIRONMENT]`](#dvc-targeting-disable-feature-environment)
+* [`dvc targeting enable [FEATURE] [ENVIRONMENT]`](#dvc-targeting-enable-feature-environment)
+* [`dvc targeting get [FEATURE] [ENVIRONMENT]`](#dvc-targeting-get-feature-environment)
 
-## `dvc targeting get [FEATURE]`
+## `dvc targeting disable [FEATURE] [ENVIRONMENT]`
+
+Disable the Targeting for the specified Environment on a Feature
+
+```
+USAGE
+  $ dvc targeting disable [FEATURE] [ENVIRONMENT] [--config-path <value>] [--auth-path <value>] [--repo-config-path
+    <value>] [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+
+ARGUMENTS
+  FEATURE      The Feature for the Targeting Rules
+  ENVIRONMENT  The Environment where the Targeting Rules will be enabled
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Disable the Targeting for the specified Environment on a Feature
+
+EXAMPLES
+  $ dvc targeting disable feature-one environment-one
+```
+
+## `dvc targeting enable [FEATURE] [ENVIRONMENT]`
+
+Enable the Targeting for the specified Environment on a Feature
+
+```
+USAGE
+  $ dvc targeting enable [FEATURE] [ENVIRONMENT] [--config-path <value>] [--auth-path <value>] [--repo-config-path
+    <value>] [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+
+ARGUMENTS
+  FEATURE      The Feature for the Targeting Rules
+  ENVIRONMENT  The Environment where the Targeting Rules will be enabled
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Enable the Targeting for the specified Environment on a Feature
+
+EXAMPLES
+  $ dvc targeting enable feature-one environment-one
+```
+
+## `dvc targeting get [FEATURE] [ENVIRONMENT]`
 
 Retrieve Targeting for a Feature from the Management API
 
 ```
 USAGE
-  $ dvc targeting get [FEATURE] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>]
-    [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [-e <value>]
+  $ dvc targeting get [FEATURE] [ENVIRONMENT] [--config-path <value>] [--auth-path <value>] [--repo-config-path
+    <value>] [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
 
 ARGUMENTS
-  FEATURE  The Feature to get the Targeting Rules
-
-FLAGS
-  -e, --env=<value>  Environment to fetch the Feature Configuration
+  FEATURE      The Feature to get the Targeting Rules
+  ENVIRONMENT  The Environment to get the Targeting Rules
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -2316,6 +2316,198 @@
       },
       "args": {}
     },
+    "targeting:disable": {
+      "id": "targeting:disable",
+      "description": "Disable the Targeting for the specified Environment on a Feature",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %> feature-one environment-one"
+      ],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
+        }
+      },
+      "args": {
+        "feature": {
+          "name": "feature",
+          "description": "The Feature for the Targeting Rules"
+        },
+        "environment": {
+          "name": "environment",
+          "description": "The Environment where the Targeting Rules will be enabled"
+        }
+      }
+    },
+    "targeting:enable": {
+      "id": "targeting:enable",
+      "description": "Enable the Targeting for the specified Environment on a Feature",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %> feature-one environment-one"
+      ],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
+        }
+      },
+      "args": {
+        "feature": {
+          "name": "feature",
+          "description": "The Feature for the Targeting Rules"
+        },
+        "environment": {
+          "name": "environment",
+          "description": "The Environment where the Targeting Rules will be enabled"
+        }
+      }
+    },
     "targeting:get": {
       "id": "targeting:get",
       "description": "Retrieve Targeting for a Feature from the Management API",
@@ -2400,20 +2592,17 @@
             "bitbucket.code_usages",
             "cli"
           ]
-        },
-        "env": {
-          "name": "env",
-          "type": "option",
-          "char": "e",
-          "description": "Environment to fetch the Feature Configuration",
-          "required": false,
-          "multiple": false
         }
       },
       "args": {
         "feature": {
           "name": "feature",
           "description": "The Feature to get the Targeting Rules"
+        },
+        "environment": {
+          "name": "environment",
+          "description": "The Environment to get the Targeting Rules",
+          "required": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
       "status": {
         "description": "Check CLI status"
       },
+      "targeting": {
+        "description": "Access and Modify Targeting Rules for a Feature with the Management API."
+      },
       "generate": {
         "description": "Generate Devcycle related files"
       }

--- a/src/api/targeting.ts
+++ b/src/api/targeting.ts
@@ -54,7 +54,7 @@ export const fetchTargetingForFeature = async (
     project_id: string,
     feature_key: string,
     environment_key?: string
-): Promise<TargetingRules> => {
+): Promise<TargetingRules[]> => {
     const url = `/v1/projects/${project_id}/features/${feature_key}/configurations` +
         `${environment_key ? `?environment=${environment_key}` : ''}`
     const response = await apiClient.get(url, {
@@ -64,5 +64,54 @@ export const fetchTargetingForFeature = async (
         },
     })
 
-    return response.data[0]
+    return response.data
+}
+
+export const enableTargeting = async (
+    token: string,
+    project_id: string,
+    feature_key: string,
+    environment_key: string
+): Promise<TargetingRules> => {
+    const targetingEnabledResponse = await updateTargetingStatusForFeatureAndEnvironment(
+        token,
+        project_id,
+        feature_key,
+        environment_key,
+        TargetingStatus.active
+    )
+    return targetingEnabledResponse.data
+}
+
+export const disableTargeting = async (
+    token: string,
+    project_id: string,
+    feature_key: string,
+    environment_key: string
+): Promise<TargetingRules> => {
+    const targetingDisabledResponse = await updateTargetingStatusForFeatureAndEnvironment(
+        token,
+        project_id,
+        feature_key,
+        environment_key,
+        TargetingStatus.inactive
+    )
+    return targetingDisabledResponse.data
+}
+
+const updateTargetingStatusForFeatureAndEnvironment = async (
+    token: string,
+    project_id: string,
+    feature_key: string,
+    environment_key: string,
+    status: TargetingStatus
+) => {
+    const url = `/v1/projects/${project_id}/features/${feature_key}/configurations` +
+        `?environment=${environment_key}`
+    return apiClient.patch(url, { status }, {
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: token,
+        },
+    })
 }

--- a/src/api/targeting.ts
+++ b/src/api/targeting.ts
@@ -54,7 +54,7 @@ export const fetchTargetingForFeature = async (
     project_id: string,
     feature_key: string,
     environment_key?: string
-): Promise<TargetingRules[]> => {
+): Promise<TargetingRules> => {
     const url = `/v1/projects/${project_id}/features/${feature_key}/configurations` +
         `${environment_key ? `?environment=${environment_key}` : ''}`
     const response = await apiClient.get(url, {
@@ -64,5 +64,5 @@ export const fetchTargetingForFeature = async (
         },
     })
 
-    return response.data
+    return response.data[0]
 }

--- a/src/commands/targeting/disable.ts
+++ b/src/commands/targeting/disable.ts
@@ -1,0 +1,69 @@
+import { Args } from '@oclif/core'
+import inquirer from 'inquirer'
+import { disableTargeting } from '../../api/targeting'
+import { environmentPrompt, featurePrompt } from '../../ui/prompts'
+import Base from '../base'
+
+export default class DisableTargeting extends Base {
+    static hidden = false
+    static description = 'Disable the Targeting for the specified Environment on a Feature'
+    static examples = [
+        '<%= config.bin %> <%= command.id %> feature-one environment-one',
+    ]
+    static flags = Base.flags
+    static args = {
+        feature: Args.string({ description: 'The Feature for the Targeting Rules' }),
+        environment: Args.string({ description: 'The Environment where the Targeting Rules will be enabled' })
+    }
+
+    authRequired = true
+
+    public async run(): Promise<void> {
+        const { args, flags } = await this.parse(DisableTargeting)
+
+        await this.requireProject()
+
+        let responses
+
+        const feature = args['feature']
+        const environment = args['environment']
+
+        if (flags.headless && (!feature || !environment)) {
+            throw new Error('In headless mode, both the feature and environment are required')
+        }
+
+        if (feature) {
+            responses = { featureKey: feature }
+        } else {
+            const userSelectedFeature = await inquirer.prompt(
+                [featurePrompt],
+                {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                }
+            )
+            responses = { featureKey: userSelectedFeature.feature }
+        }
+
+        if (environment) {
+            responses = { ...responses, environmentKey: environment }
+        } else {
+            const userSelectedEnv = await inquirer.prompt(
+                [environmentPrompt],
+                {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                }
+            )
+            responses = { ...responses, environmentKey: userSelectedEnv._environment }
+        }
+
+        const disableTargetingForFeatureAndEnvironment = await disableTargeting(
+            this.authToken,
+            this.projectKey,
+            responses.featureKey,
+            responses.environmentKey
+        )
+        return this.writer.showResults(disableTargetingForFeatureAndEnvironment)
+    }
+}

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -1,0 +1,69 @@
+import { Args } from '@oclif/core'
+import inquirer from 'inquirer'
+import { enableTargeting } from '../../api/targeting'
+import { environmentPrompt, featurePrompt } from '../../ui/prompts'
+import Base from '../base'
+
+export default class EnableTargeting extends Base {
+    static hidden = false
+    static description = 'Enable the Targeting for the specified Environment on a Feature'
+    static examples = [
+        '<%= config.bin %> <%= command.id %> feature-one environment-one',
+    ]
+    static flags = Base.flags
+    static args = {
+        feature: Args.string({ description: 'The Feature for the Targeting Rules' }),
+        environment: Args.string({ description: 'The Environment where the Targeting Rules will be enabled' })
+    }
+
+    authRequired = true
+
+    public async run(): Promise<void> {
+        const { args, flags } = await this.parse(EnableTargeting)
+
+        await this.requireProject()
+
+        let responses
+
+        const feature = args['feature']
+        const environment = args['environment']
+
+        if (flags.headless && (!feature || !environment)) {
+            throw new Error('In headless mode, both the feature and environment are required')
+        }
+
+        if (feature) {
+            responses = { featureKey: feature }
+        } else {
+            const userSelectedFeature = await inquirer.prompt(
+                [featurePrompt],
+                {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                }
+            )
+            responses = { featureKey: userSelectedFeature.feature }
+        }
+
+        if (environment) {
+            responses = { ...responses, environmentKey: environment }
+        } else {
+            const userSelectedEnv = await inquirer.prompt(
+                [environmentPrompt],
+                {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                }
+            )
+            responses = { ...responses, environmentKey: userSelectedEnv._environment }
+        }
+
+        const enableTargetingForFeatureAndEnvironment = await enableTargeting(
+            this.authToken,
+            this.projectKey,
+            responses.featureKey,
+            responses.environmentKey
+        )
+        return this.writer.showResults(enableTargetingForFeatureAndEnvironment)
+    }
+}

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -11,16 +11,10 @@ export default class DetailedTargeting extends Base {
         '<%= config.bin %> <%= command.id %> feature-one',
         '<%= config.bin %> <%= command.id %> feature-one environment-one',
     ]
-    static flags = {
-        ...Base.flags,
-        'env': Flags.string({
-            char: 'e',
-            description: 'Environment to fetch the Feature Configuration',
-            required: false
-        })
-    }
+    static flags = Base.flags
     static args = {
-        feature: Args.string({ description: 'The Feature to get the Targeting Rules' })
+        feature: Args.string({ description: 'The Feature to get the Targeting Rules' }),
+        environment: Args.string({ description: 'The Environment to get the Targeting Rules', required: false })
     }
 
     authRequired = true
@@ -33,7 +27,7 @@ export default class DetailedTargeting extends Base {
         let responses
 
         const feature = args['feature']
-        const environment = flags.env
+        const environment = args['environment']
 
         if (flags.headless && !feature) {
             this.writer.showError('In headless mode, the feature is required')

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -1,4 +1,4 @@
-import { Args, Flags } from '@oclif/core'
+import { Args } from '@oclif/core'
 import inquirer from 'inquirer'
 import { fetchTargetingForFeature } from '../../api/targeting'
 import { featurePrompt } from '../../ui/prompts'


### PR DESCRIPTION
- refactor `dvc targeting get <feature> <env>` to have `<env>` as a param instead of a `--env` flag
- add `dvc targeting enable <feature> <env>`
- add `dvc targeting disable <feature> <env>`