### PR TITLE
[feat] add variations create

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ USAGE
 * [`dvc targeting`](docs/targeting.md) - Access and Modify Targeting Rules for a Feature with the Management API.
 * [`dvc usages`](docs/usages.md) - Print all DevCycle variable usages in the current version of your code.
 * [`dvc variables`](docs/variables.md) - Access or modify Variables with the Management API
-* [`dvc variations`](docs/variations.md)
+* [`dvc variations`](docs/variations.md) - Create a new Variation
 
 <!-- commandsstop -->
 # Repo Configuration

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -16,7 +16,7 @@ Create a new Environment for an existing Feature.
 USAGE
   $ dvc environments create [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--key <value>] [--name <value>]
-    [--description <value>] [--type development|staging|production|disaster_recovery]
+    [--type development|staging|production|disaster_recovery] [--description <value>]
 
 FLAGS
   --description=<value>  Description for the dashboard

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -16,7 +16,7 @@ Create a new Variable for an existing Feature.
 USAGE
   $ dvc variables create [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--key <value>] [--name <value>]
-    [--description <value>] [--type String|Boolean|Number|JSON] [--feature <value>]
+    [--type String|Boolean|Number|JSON] [--feature <value>] [--description <value>]
 
 FLAGS
   --description=<value>  Description for the dashboard

--- a/docs/variations.md
+++ b/docs/variations.md
@@ -38,6 +38,11 @@ GLOBAL FLAGS
 
 DESCRIPTION
   Create a new Variation
+
+EXAMPLES
+  $ dvc variations create
+
+  $ dvc variations create --variables='{ "bool-var": true, "num-var": 80, "string-var": "test" }'
 ```
 
 ## `dvc variations get [FEATURE]`

--- a/docs/variations.md
+++ b/docs/variations.md
@@ -1,12 +1,48 @@
 `dvc variations`
 ================
 
+Create a new Variation
 
-
+* [`dvc variations create [FEATURE]`](#dvc-variations-create-feature)
 * [`dvc variations get [FEATURE]`](#dvc-variations-get-feature)
 * [`dvc variations list [FEATURE]`](#dvc-variations-list-feature)
 
+## `dvc variations create [FEATURE]`
+
+Create a new Variation
+
+```
+USAGE
+  $ dvc variations create [FEATURE] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>]
+    [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--key <value>] [--name
+    <value>] [--variables <value>]
+
+ARGUMENTS
+  FEATURE  Feature key or id
+
+FLAGS
+  --key=<value>        Unique ID
+  --name=<value>       Human readable name
+  --variables=<value>  The variables to create for the variation
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Create a new Variation
+```
+
 ## `dvc variations get [FEATURE]`
+
+Retrieve variations for a feature from the management API
 
 ```
 USAGE
@@ -26,9 +62,14 @@ GLOBAL FLAGS
                               warnings about missing credentials.
   --project=<value>           Project key to use for the DevCycle API requests
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Retrieve variations for a feature from the management API
 ```
 
 ## `dvc variations list [FEATURE]`
+
+List the keys of all variations in a feature
 
 ```
 USAGE
@@ -48,4 +89,7 @@ GLOBAL FLAGS
                               warnings about missing credentials.
   --project=<value>           Project key to use for the DevCycle API requests
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  List the keys of all variations in a feature
 ```

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -3208,6 +3208,10 @@
       "pluginType": "core",
       "hidden": false,
       "aliases": [],
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --variables='{ \"bool-var\": true, \"num-var\": 80, \"string-var\": \"test\" }'"
+      ],
       "flags": {
         "config-path": {
           "name": "config-path",

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -264,12 +264,6 @@
           "type": "option",
           "description": "Human readable name",
           "multiple": false
-        },
-        "description": {
-          "name": "description",
-          "type": "option",
-          "description": "Description for the dashboard",
-          "multiple": false
         }
       },
       "args": {}
@@ -845,12 +839,6 @@
           "description": "Human readable name",
           "multiple": false
         },
-        "description": {
-          "name": "description",
-          "type": "option",
-          "description": "Description for the dashboard",
-          "multiple": false
-        },
         "type": {
           "name": "type",
           "type": "option",
@@ -862,6 +850,12 @@
             "production",
             "disaster_recovery"
           ]
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "description": "Description for the dashboard",
+          "multiple": false
         }
       },
       "args": {}
@@ -2922,12 +2916,6 @@
           "description": "Human readable name",
           "multiple": false
         },
-        "description": {
-          "name": "description",
-          "type": "option",
-          "description": "Description for the dashboard",
-          "multiple": false
-        },
         "type": {
           "name": "type",
           "type": "option",
@@ -2944,6 +2932,12 @@
           "name": "feature",
           "type": "option",
           "description": "The key or id of the feature to create the variable for",
+          "multiple": false
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "description": "Description for the dashboard",
           "multiple": false
         }
       },
@@ -3205,8 +3199,116 @@
       },
       "args": {}
     },
+    "variations:create": {
+      "id": "variations:create",
+      "description": "Create a new Variation",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
+        },
+        "key": {
+          "name": "key",
+          "type": "option",
+          "description": "Unique ID",
+          "multiple": false
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Human readable name",
+          "multiple": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "option",
+          "description": "The variables to create for the variation",
+          "multiple": false
+        }
+      },
+      "args": {
+        "feature": {
+          "name": "feature",
+          "description": "Feature key or id"
+        }
+      }
+    },
     "variations:get": {
       "id": "variations:get",
+      "description": "Retrieve variations for a feature from the management API",
       "strict": true,
       "pluginName": "@devcycle/cli",
       "pluginAlias": "@devcycle/cli",
@@ -3295,6 +3397,7 @@
     },
     "variations:list": {
       "id": "variations:list",
+      "description": "List the keys of all variations in a feature",
       "strict": true,
       "pluginName": "@devcycle/cli",
       "pluginAlias": "@devcycle/cli",

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -76,7 +76,7 @@ export const updateVariable = async (
         })
 }
 
-export const fetchVariables = async (token: string, project_id: string) => {
+export const fetchVariables = async (token: string, project_id: string, feature_id?: string) => {
     return await apiClient.get('/v1/projects/:project/variables', {
         headers: {
             'Content-Type': 'application/json',
@@ -84,6 +84,9 @@ export const fetchVariables = async (token: string, project_id: string) => {
         },
         params: {
             project: project_id,
+        },
+        queries: {
+            ...(feature_id && { feature: feature_id })
         }
     })
 }

--- a/src/api/variations.ts
+++ b/src/api/variations.ts
@@ -1,8 +1,42 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator'
 import apiClient from './apiClient'
-import { Variation } from './schemas'
+import { Feature, Variation } from './schemas'
+
+export class CreateVariationParams {
+    @IsString()
+    @IsNotEmpty()
+    key: string
+
+    @IsString()
+    @IsNotEmpty()
+    name: string
+
+    @IsOptional()
+    variables?: { [key: string]: string | number | boolean | Record<string, unknown> }
+}
 
 export const fetchVariations = async (token: string, project_id: string, feature_key: string): Promise<Variation[]> => {
     const response = await apiClient.get('/v1/projects/:project/features/:feature/variations', {
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: token,
+        },
+        params: {
+            project: project_id,
+            feature: feature_key,
+        }
+    })
+
+    return response
+}
+
+export const createVariation = async (
+    token: string,
+    project_id: string,
+    feature_key: string,
+    variation: CreateVariationParams
+): Promise<Feature> => {
+    const response = await apiClient.post('/v1/projects/:project/features/:feature/variations', variation, {
         headers: {
             'Content-Type': 'application/json',
             Authorization: token,

--- a/src/commands/cleanup/index.ts
+++ b/src/commands/cleanup/index.ts
@@ -8,7 +8,14 @@ import VarAliasFlag, { getVariableAliases } from '../../flags/var-alias'
 import { EngineOptions } from '../../utils/refactor/RefactorEngine'
 import { Variable } from './types'
 import { ENGINES } from '../../utils/refactor'
-import { variablePrompt, variablePromptNoApi, variableTypePrompt, variableValuePrompt } from '../../ui/prompts'
+import {
+    variablePrompt,
+    variablePromptNoApi,
+    variableTypePrompt,
+    variableValueBooleanPrompt,
+    variableValueNumberPrompt,
+    variableValueStringPrompt
+} from '../../ui/prompts'
 
 export default class Cleanup extends Base {
     static hidden = false
@@ -93,8 +100,20 @@ export default class Cleanup extends Base {
             variable.type = input.type
         }
         if (!variable.value) {
-            const input = await inquirer.prompt([variableValuePrompt])
-            variable.value = input.value
+            let question
+            switch (variable.type) {
+                case 'Boolean':
+                    question =variableValueBooleanPrompt(variable.key)
+                    break
+                case 'Number':
+                    question = variableValueNumberPrompt(variable.key)
+                    break
+                default:
+                    question = variableValueStringPrompt(variable.key)
+            }
+
+            const input = await inquirer.prompt([question])
+            variable.value = input[variable.key]
         }
 
         const includeFile = (filepath: string) => {

--- a/src/commands/cleanup/index.ts
+++ b/src/commands/cleanup/index.ts
@@ -8,14 +8,7 @@ import VarAliasFlag, { getVariableAliases } from '../../flags/var-alias'
 import { EngineOptions } from '../../utils/refactor/RefactorEngine'
 import { Variable } from './types'
 import { ENGINES } from '../../utils/refactor'
-import {
-    variablePrompt,
-    variablePromptNoApi,
-    variableTypePrompt,
-    variableValueBooleanPrompt,
-    variableValueNumberPrompt,
-    variableValueStringPrompt
-} from '../../ui/prompts'
+import { variablePrompt, variablePromptNoApi, variableTypePrompt, variableValueStringPrompt } from '../../ui/prompts'
 
 export default class Cleanup extends Base {
     static hidden = false
@@ -100,19 +93,7 @@ export default class Cleanup extends Base {
             variable.type = input.type
         }
         if (!variable.value) {
-            let question
-            switch (variable.type) {
-                case 'Boolean':
-                    question =variableValueBooleanPrompt(variable.key)
-                    break
-                case 'Number':
-                    question = variableValueNumberPrompt(variable.key)
-                    break
-                default:
-                    question = variableValueStringPrompt(variable.key)
-            }
-
-            const input = await inquirer.prompt([question])
+            const input = await inquirer.prompt([variableValueStringPrompt(variable.key)])
             variable.value = input[variable.key]
         }
 

--- a/src/commands/createCommand.ts
+++ b/src/commands/createCommand.ts
@@ -21,9 +21,6 @@ export default abstract class CreateCommand<ResourceType> extends Base {
         'name': Flags.string({
             description: 'Human readable name',
         }),
-        'description': Flags.string({
-            description: 'Description for the dashboard',
-        }),
     }
 
     public async populateParameters(

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -28,6 +28,9 @@ export default class CreateEnvironment extends CreateCommand<CreateEnvironmentPa
             description: 'The type of environment',
             options: environmentTypes
         }),
+        'description': Flags.string({
+            description: 'Description for the dashboard',
+        }),
     }
 
     public async run(): Promise<void> {

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -1,3 +1,4 @@
+import { Flags } from '@oclif/core'
 import { createProject, CreateProjectParams } from '../../api/projects'
 import { descriptionPrompt, keyPrompt, namePrompt } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
@@ -7,6 +8,13 @@ export default class CreateProject extends CreateCommand<CreateProjectParams> {
     static description = 'Create a new Project'
 
     prompts = [keyPrompt, namePrompt, descriptionPrompt]
+
+    static flags = {
+        ...CreateCommand.flags,
+        'description': Flags.string({
+            description: 'Description for the dashboard',
+        }),
+    }
 
     public async run(): Promise<void> {
         const { flags } = await this.parse(CreateProject)

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -25,7 +25,10 @@ export default class CreateVariable extends CreateCommand<CreateVariableParams> 
         }),
         'feature': Flags.string({
             description: 'The key or id of the feature to create the variable for'
-        })
+        }),
+        'description': Flags.string({
+            description: 'Description for the dashboard',
+        }),
     }
 
     prompts = [

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -1,0 +1,89 @@
+import inquirer from 'inquirer'
+import { Args, Flags } from '@oclif/core'
+import {
+    featurePrompt,
+    keyPrompt,
+    namePrompt,
+    variableValueBooleanPrompt,
+    variableValueNumberPrompt,
+    variableValueStringPrompt
+} from '../../ui/prompts'
+import CreateCommand from '../createCommand'
+import { createVariation, CreateVariationParams } from '../../api/variations'
+import { fetchVariables } from '../../api/variables'
+
+export default class CreateVariation extends CreateCommand<CreateVariationParams> {
+    static hidden = false
+    static description = 'Create a new Variation'
+
+    static args = {
+        feature: Args.string({
+            name: 'feature',
+            description: 'Feature key or id'
+        })
+    }
+
+    static flags = {
+        ...CreateCommand.flags,
+        'variables': Flags.string({
+            description: 'The variables to create for the variation'
+        }),
+    }
+
+    prompts = [keyPrompt, namePrompt]
+
+    public async run(): Promise<void> {
+        await this.requireProject()
+
+        const { args, flags } = await this.parse(CreateVariation)
+        const { headless, key, name, variables } = flags
+        if (headless && (!key || !name)) {
+            this.writer.showError('In headless mode, the key and name flags are required')
+            return
+        }
+
+        let featureKey
+        if (!args.feature) {
+            const { feature } = await inquirer.prompt([featurePrompt], {
+                token: this.authToken,
+                projectKey: this.projectKey
+            })
+
+            featureKey = feature
+        } else {
+            featureKey = args.feature
+        }
+
+        const params = await this.populateParameters(CreateVariationParams, false, {
+            key,
+            name,
+            headless
+        })
+
+        let variableAnswers = {}
+        if (!variables) {
+            const variablesForFeature = await fetchVariables(this.authToken, this.projectKey, featureKey)
+            const variablePrompts = []
+            for (const variable of variablesForFeature) {
+                if (variable.type === 'Boolean') {
+                    variablePrompts.push(variableValueBooleanPrompt(variable.key))
+                } else if (variable.type === 'Number') {
+                    variablePrompts.push(variableValueNumberPrompt(variable.key))
+                } else {
+                    variablePrompts.push(variableValueStringPrompt(variable.key))
+                }
+            }
+
+            variableAnswers = await inquirer.prompt(variablePrompts, {})
+        }
+
+        const variation = {
+            key: params.key,
+            name: params.name,
+            variables: variables ? variables : variableAnswers
+        }
+
+        const result = await createVariation(this.authToken, this.projectKey, featureKey, variation)
+        this.writer.showResults(result)
+    }
+}

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -30,6 +30,11 @@ export default class CreateVariation extends CreateCommand<CreateVariationParams
         }),
     }
 
+    static examples = [
+        '<%= config.bin %> <%= command.id %>',
+        '<%= config.bin %> <%= command.id %> --variables=\'{ "bool-var": true, "num-var": 80, "string-var": "test" }\''
+    ]
+
     prompts = [keyPrompt, namePrompt]
 
     public async run(): Promise<void> {
@@ -80,7 +85,7 @@ export default class CreateVariation extends CreateCommand<CreateVariationParams
         const variation = {
             key: params.key,
             name: params.name,
-            variables: variables ? variables : variableAnswers
+            variables: variables ? JSON.parse(variables) : variableAnswers
         }
 
         const result = await createVariation(this.authToken, this.projectKey, featureKey, variation)

--- a/src/commands/variations/get.ts
+++ b/src/commands/variations/get.ts
@@ -7,6 +7,7 @@ import { Args } from '@oclif/core'
 export default class GetVariations extends Base {
     static hidden = false
     authRequired = true
+    static description = 'Retrieve variations for a feature from the management API'
 
     static args = {
         feature: Args.string({

--- a/src/commands/variations/list.ts
+++ b/src/commands/variations/list.ts
@@ -7,6 +7,7 @@ import { Args } from '@oclif/core'
 export default class ListVariations extends Base {
     static hidden = false
     authRequired = true
+    static description = 'List the keys of all variations in a feature'
 
     static args = {
         feature: Args.string({

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -83,3 +83,23 @@ export const variableValueBooleanPrompt  = (variableKey: string): ListQuestion =
         ]
     }
 }
+
+export const variableValueJSONPrompt  = (variableKey: string): Question => {
+    return {
+        name: variableKey,
+        message: `Variable value for ${variableKey}`,
+        type: 'input',
+        validate: (input: string): boolean | string => {
+            try {
+                const parsedInput = JSON.parse(input)
+                if (typeof parsedInput === 'object') {
+                    return true
+                } else {
+                    return 'Please enter a valid JSON object'
+                }
+            } catch (e) {
+                return 'Please enter a valid JSON object'
+            }
+        } 
+    }
+}

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -1,5 +1,7 @@
 import { Variable } from '../../api/schemas'
 import { fetchVariables, variableTypes } from '../../api/variables'
+import { ListQuestion, Question } from 'inquirer'
+
 type VariableChoice = {
     name: string,
     value: Variable
@@ -36,7 +38,48 @@ export const variableTypePrompt = {
     choices: variableTypes
 }
 
-export const variableValuePrompt = {
-    name: 'value',
-    message: 'Variable value'
+export const variableValueStringPrompt = (variableKey: string): Question => {
+    return {
+        name: variableKey,
+        message: `Variable value for ${variableKey}`,
+    }
+}
+
+export const variableValueNumberPrompt = (variableKey: string): Question => {
+    return {
+        name: variableKey,
+        message: `Variable value for ${variableKey}`,
+        type: 'input',
+        filter: (input: string): number | string => {
+            if (isNaN(Number(input))) {
+                return 'NaN'
+            } else {
+                return Number(input)
+            }
+        },
+        validate: (input: string): boolean | string => {
+            if (isNaN(Number(input))) {
+                return 'Please enter a number'
+            }
+            return true
+        } 
+    }
+}
+
+export const variableValueBooleanPrompt  = (variableKey: string): ListQuestion => {
+    return {
+        name: variableKey,
+        message: `Variable value for ${variableKey}`,
+        type: 'list',
+        choices: [
+            {
+                name: 'true',
+                value: true
+            },
+            {
+                name: 'false',
+                value: false
+            }
+        ]
+    }
 }


### PR DESCRIPTION
TODO: add some tests! -- tested manually, will create ticket for tests
- add variations create command
- prompts for variables values (with proper types) if optional variables flag is not passed in
- ~~refactor cleanup command to use updated variable values prompt, which returns the correct types now~~
    - keep the cleanup command variable values prompt to use `variableValueStringPrompt`, as the types are handled in `src/utils/refactor/RefactorEngine.ts`

![cli-variations-create](https://github.com/DevCycleHQ/cli/assets/98763537/9978c081-bb01-41d8-9d26-f7913577a525)

JSON variable: 

![cli-variations-create-json](https://github.com/DevCycleHQ/cli/assets/98763537/3582e1b0-9ccb-4acb-8519-5b20694d7ff4)
