### PR TITLE
fix: headless mode being ignored on variable and environment update

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -6,7 +6,7 @@ Create a new Environment for an existing Feature.
 * [`dvc environments create`](#dvc-environments-create)
 * [`dvc environments get`](#dvc-environments-get)
 * [`dvc environments list`](#dvc-environments-list)
-* [`dvc environments update`](#dvc-environments-update)
+* [`dvc environments update [KEY]`](#dvc-environments-update-key)
 
 ## `dvc environments create`
 
@@ -91,14 +91,22 @@ GLOBAL FLAGS
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```
 
-## `dvc environments update`
+## `dvc environments update [KEY]`
 
 Update a Environment.
 
 ```
 USAGE
-  $ dvc environments update [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
-    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+  $ dvc environments update [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--name <value>] [--key <value>]
+    [--type development|staging|production|disaster_recovery] [--description <value>]
+
+FLAGS
+  --description=<value>  Description for the environment
+  --key=<value>          Unique ID
+  --name=<value>         Human readable name
+  --type=<option>        The type of environment
+                         <options: development|staging|production|disaster_recovery>
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -6,7 +6,7 @@ Access or modify Variables with the Management API
 * [`dvc variables create`](#dvc-variables-create)
 * [`dvc variables get`](#dvc-variables-get)
 * [`dvc variables list`](#dvc-variables-list)
-* [`dvc variables update`](#dvc-variables-update)
+* [`dvc variables update [KEY]`](#dvc-variables-update-key)
 
 ## `dvc variables create`
 
@@ -82,14 +82,20 @@ GLOBAL FLAGS
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 ```
 
-## `dvc variables update`
+## `dvc variables update [KEY]`
 
 Update a Variable.
 
 ```
 USAGE
-  $ dvc variables update [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
-    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+  $ dvc variables update [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--name <value>] [--description
+    <value>] [--feature <value>]
+
+FLAGS
+  --description=<value>  Description for the variable
+  --feature=<value>      The ID of the feature to associate the variable to
+  --name=<value>         Human readable name
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -347,9 +347,19 @@
             "bitbucket.code_usages",
             "cli"
           ]
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Human readable name",
+          "multiple": false
         }
       },
-      "args": {}
+      "args": {
+        "key": {
+          "name": "key"
+        }
+      }
     },
     "wink": {
       "id": "wink",
@@ -1117,9 +1127,43 @@
             "bitbucket.code_usages",
             "cli"
           ]
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Human readable name",
+          "multiple": false
+        },
+        "key": {
+          "name": "key",
+          "type": "option",
+          "description": "Unique ID",
+          "multiple": false
+        },
+        "type": {
+          "name": "type",
+          "type": "option",
+          "description": "The type of environment",
+          "multiple": false,
+          "options": [
+            "development",
+            "staging",
+            "production",
+            "disaster_recovery"
+          ]
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "description": "Description for the environment",
+          "multiple": false
         }
       },
-      "args": {}
+      "args": {
+        "key": {
+          "name": "key"
+        }
+      }
     },
     "features:delete": {
       "id": "features:delete",
@@ -3195,9 +3239,31 @@
             "bitbucket.code_usages",
             "cli"
           ]
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Human readable name",
+          "multiple": false
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "description": "Description for the variable",
+          "multiple": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "option",
+          "description": "The ID of the feature to associate the variable to",
+          "multiple": false
         }
       },
-      "args": {}
+      "args": {
+        "key": {
+          "name": "key"
+        }
+      }
     },
     "variations:create": {
       "id": "variations:create",

--- a/src/commands/createCommand.ts
+++ b/src/commands/createCommand.ts
@@ -1,16 +1,7 @@
 import { Flags } from '@oclif/core'
-import { ClassConstructor, plainToClass } from 'class-transformer'
-import { validateSync } from 'class-validator'
-import inquirer from 'inquirer'
-import { reportValidationErrors } from '../utils/reportValidationErrors'
 import Base from './base'
 
-type prompts = {
-    name: string; message: string; type: string;
-}
-
-export default abstract class CreateCommand<ResourceType> extends Base {
-    prompts: prompts[] = []
+export default abstract class CreateCommand extends Base {
     authRequired = true
 
     static flags = {
@@ -21,56 +12,5 @@ export default abstract class CreateCommand<ResourceType> extends Base {
         'name': Flags.string({
             description: 'Human readable name',
         }),
-    }
-
-    public async populateParameters(
-        paramClass: ClassConstructor<ResourceType>,
-        requireProject = true,
-        flags: Record<string, unknown> = {},
-    ): Promise<ResourceType> {
-        this.filterPrompts(flags)
-        if (requireProject) {
-            await this.requireProject()
-        }
-        if (flags.headless) {
-            const params = plainToClass(paramClass, flags)
-            const errors = validateSync(params as Record<string, unknown>, {
-                whitelist: true,
-            })
-            reportValidationErrors(paramClass.name, errors)
-            return params
-        }
-        const answers = await this.populateParametersWithInquirer()
-
-        const params = plainToClass(paramClass, this.mergeFlagsAndAnswers(flags, answers))
-        const errors = validateSync(params as Record<string, unknown>, {
-            whitelist: true,
-        })
-        reportValidationErrors(paramClass.name, errors)
-        return params
-    }
-
-    private async populateParametersWithInquirer() {
-        return await inquirer.prompt(this.prompts, {
-            token: this.authToken,
-            projectKey: this.projectKey,
-        })
-    }
-
-    private async filterPrompts(flags: Record<string, unknown>) {
-        Object.keys(flags).forEach((key) => {
-            if (flags[key]) {
-                this.prompts = this.prompts.filter((prompt) => prompt.name !== key)
-            }
-        })
-    }
-
-    private mergeFlagsAndAnswers(flags: Record<string, unknown>, answers: Record<string, unknown>) {
-        Object.keys(flags).forEach((key) => {
-            if (flags[key] === undefined) {
-                flags[key] = answers[key]
-            }
-        })
-        return flags
     }
 }

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -12,7 +12,7 @@ import {
 } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
 
-export default class CreateEnvironment extends CreateCommand<CreateEnvironmentParams> {
+export default class CreateEnvironment extends CreateCommand {
     static hidden = false
     static description = 'Create a new Environment for an existing Feature.'
 
@@ -35,22 +35,18 @@ export default class CreateEnvironment extends CreateCommand<CreateEnvironmentPa
 
     public async run(): Promise<void> {
         const { flags } = await this.parse(CreateEnvironment)
+        const { key, name, type, headless } = flags
 
-        const { key, name, type, description, headless } = flags
-
-        await this.requireProject()
         if (headless && (!type || !key || !name)) {
-            this.writer.showError('In headless mode, the type, key, and name flags are required')
+            this.writer.showError('The type, key, and name flags are required')
             return
         }
 
-        const params = await this.populateParameters(CreateEnvironmentParams, false, {
-            key,
-            name,
-            description,
-            type,
-            headless
-        })
+        const params = await this.populateParameters(
+            CreateEnvironmentParams,
+            this.prompts,
+            flags,
+        )
 
         const result = await createEnvironment(this.authToken, this.projectKey, params)
         this.writer.showResults(result)

--- a/src/commands/environments/update.ts
+++ b/src/commands/environments/update.ts
@@ -1,7 +1,8 @@
 import inquirer from 'inquirer'
 import {
     updateEnvironment,
-    CreateEnvironmentParams
+    CreateEnvironmentParams,
+    environmentTypes
 } from '../../api/environments'
 import {
     descriptionPrompt,
@@ -10,8 +11,9 @@ import {
     EnvironmentPromptResult
 } from '../../ui/prompts'
 import UpdateCommand from '../updateCommand'
+import { Flags } from '@oclif/core'
 
-export default class UpdateEnvironment extends UpdateCommand<CreateEnvironmentParams> {
+export default class UpdateEnvironment extends UpdateCommand {
     static hidden = false
     static description = 'Update a Environment.'
 
@@ -19,24 +21,53 @@ export default class UpdateEnvironment extends UpdateCommand<CreateEnvironmentPa
         namePrompt,
         descriptionPrompt
     ]
+    static flags = {
+        ...UpdateCommand.flags,
+        'key': Flags.string({
+            description: 'Unique ID'
+        }),
+        'type': Flags.string({
+            description: 'The type of environment',
+            options: environmentTypes
+        }),
+        'description': Flags.string({
+            description: 'Description for the environment',
+        }),
+    }
 
     public async run(): Promise<void> {
+        const { args, flags } = await this.parse(UpdateEnvironment)
+        const { key } = args
+        const { headless } = flags
+
         await this.requireProject()
-        const { environment } = await inquirer.prompt<EnvironmentPromptResult>([environmentPrompt], {
-            token: this.authToken,
-            projectKey: this.projectKey
-        })
+        let envKey = key
+        if (headless && !envKey) {
+            this.writer.showError('The key argument is required')
+            return
+        } else if (!envKey) {
+            const { environment } = await inquirer.prompt<EnvironmentPromptResult>([environmentPrompt], {
+                token: this.authToken,
+                projectKey: this.projectKey
+            })
+            envKey = environment._id
+            this.writer.blankLine()
+            this.writer.statusMessage('Current values:')
+            this.writer.statusMessage(JSON.stringify(environment, null, 2))
+            this.writer.blankLine()
+        }
 
-        this.writer.blankLine()
-        this.writer.statusMessage('Current values:')
-        this.writer.statusMessage(JSON.stringify(environment, null, 2))
-        this.writer.blankLine()
+        const params = await this.populateParameters(
+            CreateEnvironmentParams,
+            this.prompts,
+            flags,
+            true
+        )
 
-        const params = await this.populateParameters(CreateEnvironmentParams)
         const result = await updateEnvironment(
             this.authToken,
             this.projectKey,
-            environment._id,
+            envKey,
             params
         )
         this.writer.showResults(result)

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -3,7 +3,7 @@ import { createProject, CreateProjectParams } from '../../api/projects'
 import { descriptionPrompt, keyPrompt, namePrompt } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
 
-export default class CreateProject extends CreateCommand<CreateProjectParams> {
+export default class CreateProject extends CreateCommand {
     static hidden = false
     static description = 'Create a new Project'
 
@@ -23,12 +23,15 @@ export default class CreateProject extends CreateCommand<CreateProjectParams> {
             this.writer.showError('In headless mode, the key and name flags are required')
             return
         }
-        const params = await this.populateParameters(CreateProjectParams, false, {
-            key,
-            name,
-            description,
-            headless
-        })
+        const params = await this.populateParameters(
+            CreateProjectParams,
+            this.prompts, {
+                key,
+                name,
+                description,
+                headless
+            }
+        )
         const result = await createProject(this.authToken, params)
         this.writer.showResults(result)
     }

--- a/src/commands/variables/create.test.ts
+++ b/src/commands/variables/create.test.ts
@@ -65,7 +65,6 @@ describe('variables create', () => {
             '--name', requestBody.name,
             ...authFlags
         ])
-
         .it('prompts for missing key and description, and returns a variable',
             (ctx) => {
                 expect(JSON.parse(ctx.stdout)).to.eql(mockVariable)
@@ -84,7 +83,7 @@ describe('variables create', () => {
         ])
         .it('Errors when called in headless mode with no key',
             (ctx) => {
-                expect(ctx.stdout).to.contain('the key, name, feature and type are required')
+                expect(ctx.stdout).to.contain('The key, name, feature, and type flags are required')
             })
 
 })

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -13,7 +13,7 @@ import {
 } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
 
-export default class CreateVariable extends CreateCommand<CreateVariableParams> {
+export default class CreateVariable extends CreateCommand {
     static hidden = false
     static description = 'Create a new Variable for an existing Feature.'
 
@@ -41,21 +41,14 @@ export default class CreateVariable extends CreateCommand<CreateVariableParams> 
 
     public async run(): Promise<void> {
         const { flags } = await this.parse(CreateVariable)
-
-        const { key, name, description, type, feature, headless } = flags
-
+        const { key, name, type, feature, headless } = flags
+ 
         if (headless && (!key || !name || !type || !feature)) {
-            this.writer.showError('In headless mode, the key, name, feature and type are required')
+            this.writer.showError('The key, name, feature, and type flags are required')
             return
         }
-        const params = await this.populateParameters(CreateVariableParams, true, {
-            key,
-            name,
-            description,
-            type,
-            feature,
-            headless
-        })
+
+        const params = await this.populateParameters(CreateVariableParams, this.prompts, flags)
         const result = await createVariable(this.authToken, this.projectKey, params)
         this.writer.showResults(result)
     }

--- a/src/commands/variables/update.ts
+++ b/src/commands/variables/update.ts
@@ -4,15 +4,16 @@ import {
     CreateVariableParams
 } from '../../api/variables'
 import {
+    VariablePromptResult,
     descriptionPrompt,
     featurePrompt,
     namePrompt,
     variablePrompt,
-    VariablePromptResult
 } from '../../ui/prompts'
 import UpdateCommand from '../updateCommand'
+import { Flags } from '@oclif/core'
 
-export default class UpdateVariable extends UpdateCommand<CreateVariableParams> {
+export default class UpdateVariable extends UpdateCommand {
     static hidden = false
     static description = 'Update a Variable.'
 
@@ -22,23 +23,48 @@ export default class UpdateVariable extends UpdateCommand<CreateVariableParams> 
         featurePrompt
     ]
 
+    static flags = {
+        ...UpdateCommand.flags,
+        'description': Flags.string({
+            description: 'Description for the variable',
+        }),
+        'feature': Flags.string({
+            description: 'The ID of the feature to associate the variable to'
+        }),
+    }
+
     public async run(): Promise<void> {
+        const { args, flags } = await this.parse(UpdateVariable)
+        const { key } = args
+        const { headless } = flags
+
         await this.requireProject()
-        const { variable } = await inquirer.prompt<VariablePromptResult>([variablePrompt], {
-            token: this.authToken,
-            projectKey: this.projectKey
-        })
+        let variableKey = key
+        if (headless && !variableKey) {
+            this.writer.showError('The key argument is required')
+            return
+        } else if (!variableKey) {
+            const { variable } = await inquirer.prompt<VariablePromptResult>([variablePrompt], {
+                token: this.authToken,
+                projectKey: this.projectKey
+            })
+            variableKey = variable.key
+            this.writer.blankLine()
+            this.writer.statusMessage('Current values:')
+            this.writer.statusMessage(JSON.stringify(variable, null, 2))
+            this.writer.blankLine()
+        }
 
-        this.writer.blankLine()
-        this.writer.statusMessage('Current values:')
-        this.writer.statusMessage(JSON.stringify(variable, null, 2))
-        this.writer.blankLine()
-
-        const params = await this.populateParameters(CreateVariableParams)
+        const params = await this.populateParameters(
+            CreateVariableParams,
+            this.prompts,
+            flags,
+            true
+        )
         const result = await updateVariable(
             this.authToken,
             this.projectKey,
-            variable.key,
+            variableKey,
             params
         )
         this.writer.showResults(result)

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -13,7 +13,7 @@ import CreateCommand from '../createCommand'
 import { createVariation, CreateVariationParams } from '../../api/variations'
 import { fetchVariables } from '../../api/variables'
 
-export default class CreateVariation extends CreateCommand<CreateVariationParams> {
+export default class CreateVariation extends CreateCommand {
     static hidden = false
     static description = 'Create a new Variation'
 
@@ -60,11 +60,14 @@ export default class CreateVariation extends CreateCommand<CreateVariationParams
             featureKey = args.feature
         }
 
-        const params = await this.populateParameters(CreateVariationParams, false, {
-            key,
-            name,
-            headless
-        })
+        const params = await this.populateParameters(
+            CreateVariationParams,
+            this.prompts, {
+                key,
+                name,
+                headless
+            }
+        )
 
         let variableAnswers: Record<string, unknown> = {}
         if (!variables) {

--- a/src/ui/prompts/environmentPrompts.ts
+++ b/src/ui/prompts/environmentPrompts.ts
@@ -6,6 +6,7 @@ import {
 } from '../../api/environments'
 import { PromptResult } from '.'
 import { Environment } from '../../api/schemas'
+
 type EnvironmentChoice = {
     name: string,
     value: Environment

--- a/src/ui/prompts/index.ts
+++ b/src/ui/prompts/index.ts
@@ -2,8 +2,4 @@ export * from './commonPrompts'
 export * from './variablePrompts'
 export * from './featurePrompts'
 export * from './environmentPrompts'
-
-export type PromptResult = {
-    token: string,
-    projectKey: string
-}
+export * from './types'

--- a/src/ui/prompts/types.ts
+++ b/src/ui/prompts/types.ts
@@ -1,0 +1,11 @@
+export type PromptResult = {
+  token: string,
+  projectKey: string
+}
+
+export type Prompt = {
+    name: string
+    message: string
+    type: string
+    choices?: () => Promise<Record<string, string>[]>
+}

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -2,6 +2,7 @@ import { Variable } from '../../api/schemas'
 import { fetchVariables, variableTypes } from '../../api/variables'
 import { ListQuestion, Question } from 'inquirer'
 import { PromptResult } from '.'
+import chalk from 'chalk'
 
 type VariableChoice = {
     name: string,
@@ -16,8 +17,9 @@ export type VariablePromptResult = {
 export const variableChoices = async (input: Record<string, any>):Promise<VariableChoice[]> => {
     const variables = await fetchVariables(input.token, input.projectKey)
     const choices = variables.map((variable) => {
+        const name = variable.name ? `${variable.name} ${chalk.dim(`(${variable.key})`)}` : variable.key
         return {
-            name: variable.name || variable.key,
+            name, 
             value: variable
         }
     })

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,0 +1,35 @@
+import { ClassConstructor } from 'class-transformer'
+import { Prompt } from '../ui/prompts'
+import { ValidatorOptions, validateSync } from 'class-validator'
+import { reportValidationErrors } from './reportValidationErrors'
+
+export function validateParams<ResourceType>(
+    paramClass: ClassConstructor<ResourceType>,
+    params: ResourceType,
+    validatorOptions?: ValidatorOptions
+){
+    const errors = validateSync(params as Record<string, unknown>, { ...validatorOptions })
+    reportValidationErrors(paramClass.name, errors)
+}
+
+// Filter out prompts that already have values provided by flags
+export function filterPrompts(prompts: Prompt[], flags: Record<string, unknown>) {
+    let filteredPrompts: Prompt[] = [ ...prompts ]
+    Object.keys(flags).forEach((key) => {
+        if (flags[key]) {
+            filteredPrompts = filteredPrompts.filter((prompt) => prompt.name !== key)
+        }
+    })
+    return filteredPrompts
+}
+
+// Merge answers from prompts with values provided by flags
+export function mergeFlagsAndAnswers(flags: Record<string, unknown>, answers: Record<string, unknown>) {
+    const updatedFlags = { ...flags }
+    Object.keys(answers).forEach((key) => {
+        if (updatedFlags[key] === undefined) {
+            updatedFlags[key] = answers[key]
+        }
+    })
+    return updatedFlags
+}


### PR DESCRIPTION
# Changes
* this also addresses[ DVC-7620](https://taplytics.atlassian.net/browse/DVC-7620)
* move `populateParameters` into `Base` class
* add `key` validation for headless mode on variable and environment update
* display variable key along with the name on variable choice prompt
