### PR TITLE
Use zod schema for CreateVariableDto

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios'
 import { BASE_URL } from './common'
 import { createApiClient } from './zodClient'
+import { ZodIssueCode, ZodIssueOptionalMessage, ErrorMapCtx } from 'zod'
 
 export const axiosClient = axios.create({
     baseURL: BASE_URL,
@@ -34,6 +35,48 @@ axiosClient.interceptors.response.use(
         return Promise.reject(error)
     },
 )
+
+export const errorMap = (issue: ZodIssueOptionalMessage, ctx: ErrorMapCtx) => {
+    if (!ctx.data) {
+        return {
+            message: `${issue.path.join('.')} is a required field`,
+        }
+    }
+
+    switch (issue.code) {
+        case ZodIssueCode.too_small:
+            return {
+                message:
+                issue.type === 'string' ?
+                    `${issue.path.join('.')} length must be >= ${issue.minimum} but got ${ctx.data}`
+                    : `${issue.path.join('.')} must be >= ${issue.minimum} but got ${ctx.data}`,
+            }
+        case ZodIssueCode.too_big:
+            return {
+                message: 
+                issue.type === 'string' ?
+                    `${issue.path.join('.')} length must be <= ${issue.maximum} but got ${ctx.data}` 
+                    : `${issue.path.join('.')} must be <= ${issue.maximum} but got ${ctx.data}`,
+            }
+        case ZodIssueCode.invalid_string:
+            const regexError = `format of ${issue.path.join('.')} is invalid.`
+            const invalidTypeError = `${issue.path.join('.')} must be a valid ${issue.validation}, but got ${ctx.data}`
+            const noValidationError = `Invalid value: ${issue.path.join('.')}. ${issue.message || ''}`
+            
+            return {
+                message: issue.validation === 'regex' ? regexError 
+                    : issue.validation ? 
+                        invalidTypeError 
+                        : noValidationError,
+            }
+        case ZodIssueCode.invalid_enum_value:
+            return {
+                message: `${issue.path.join('.')} must be one of ${issue.options.join(', ')}`,
+            }
+        default:
+            return { message: ctx.defaultError }
+    }
+}
 
 export const apiClient = createApiClient(BASE_URL, { axiosInstance: axiosClient, validate: 'request' })
 export default apiClient

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -17,3 +17,9 @@ export const UpdateEnvironmentDto = schemas.UpdateEnvironmentDto
 
 export type CreateFeatureParams = z.infer<typeof schemas.CreateFeatureDto>
 export const CreateFeatureDto = schemas.CreateFeatureDto
+
+export type CreateVariableParams = z.infer<typeof schemas.CreateVariableDto>
+export const CreateVariableDto = schemas.CreateVariableDto
+
+export type UpdateVariableParams = z.infer<typeof schemas.UpdateVariableDto>
+export const UpdateVariableDto = schemas.UpdateVariableDto

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -1,30 +1,5 @@
-import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 import apiClient, { axiosClient } from './apiClient'
-import { Variable } from './schemas'
-
-export const variableTypes = ['String', 'Boolean', 'Number', 'JSON']
-
-export class CreateVariableParams {
-    @IsString()
-    @IsOptional()
-    name: string
-
-    @IsString()
-    @IsOptional()
-    description?: string
-
-    @IsNotEmpty()
-    @IsString()
-    key: string
-
-    @IsOptional()
-    @IsString()
-    feature?: string
-
-    @IsString()
-    @IsIn(variableTypes)
-    type: 'String' | 'Boolean' | 'Number' | 'JSON'
-}
+import { CreateVariableParams, Variable } from './schemas'
 
 export const createVariable = async (
     token: string,
@@ -35,7 +10,7 @@ export const createVariable = async (
         name: params.name,
         description: params.description,
         key: params.key,
-        _feature: params.feature,
+        _feature: params._feature,
         type: params.type,
     }
     return apiClient.post('/v1/projects/:project/variables', data, {
@@ -59,7 +34,7 @@ export const updateVariable = async (
         name: params?.name,
         description: params?.description,
         key: params?.key,
-        _feature: params?.feature,
+        _feature: params?._feature,
         type: params?.type,
     }
     return apiClient.patch('/v1/projects/:project/variables/:key',

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -154,7 +154,7 @@ describe('features create', () => {
         .it('returns an error if key is not provided',
             (ctx) => {
                 expect(ctx.stdout).to.contain(
-                    'Invalid value for key: undefined'
+                    'key is a required field'
                 )
             })
     
@@ -173,7 +173,7 @@ describe('features create', () => {
         .it('returns an error if name is not provided',
             (ctx) => {
                 expect(ctx.stdout).to.contain(
-                    'Invalid value for name: undefined'
+                    'name is a required field'
                 )
             })
 

--- a/src/commands/features/create.ts
+++ b/src/commands/features/create.ts
@@ -60,9 +60,7 @@ export default class CreateFeature extends CreateCommand {
         } catch (e) {
             if (e instanceof ZodError) {
                 this.reportZodValidationErrors(e)
-            }
-
-            if (e instanceof Error) {
+            } else if (e instanceof Error) {
                 this.writer.showError(e.message)
             }
         }

--- a/src/ui/prompts/featurePrompts.ts
+++ b/src/ui/prompts/featurePrompts.ts
@@ -37,6 +37,11 @@ export const featurePrompt = {
     source: featureChoices
 }
 
+export const variableFeaturePrompt = {
+    ...featurePrompt,
+    name: '_feature',
+}
+
 type SDKVisibilityChoice = {
     name: string,
     value: 'mobile' | 'client' | 'server',

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -1,5 +1,7 @@
 import inquirer from 'inquirer'
 import Writer from '../../writer'
+import { reportZodValidationErrors } from '../../../utils/reportValidationErrors'
+import { ZodError } from 'zod'
 
 /**
  * Map list items to a human readable name to make it easier to display to the user
@@ -127,7 +129,9 @@ export abstract class ListOptionsPrompt<T> {
                     return this.list.map((item) => item.value) as unknown as T[]
             }
         } catch (e) {
-            if (e instanceof Error) {
+            if (e instanceof ZodError) {
+                reportZodValidationErrors(e, this.writer)
+            } else if (e instanceof Error) {
                 this.writer.showError(e.message)
             }
         }

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -1,11 +1,11 @@
-import { Variable } from '../../api/schemas'
-import { fetchVariables, variableTypes } from '../../api/variables'
+import { CreateVariableDto, Variable } from '../../api/schemas'
+import { fetchVariables } from '../../api/variables'
 import { ListQuestion, Question } from 'inquirer'
 import { AutoCompletePrompt, Prompt, PromptResult } from '.'
 import chalk from 'chalk'
 import { autocompleteSearch } from '../autocomplete'
 import { descriptionPrompt, keyPrompt, namePrompt } from './commonPrompts'
-import { featurePrompt } from './featurePrompts'
+import { variableFeaturePrompt } from './featurePrompts'
 
 type VariableChoice = {
     name: string,
@@ -48,7 +48,7 @@ export const variableTypePrompt = {
     name: 'type',
     message: 'The type of variable',
     type: 'list',
-    choices: variableTypes
+    choices: CreateVariableDto.shape.type.options
 }
 
 export const variableValueStringPrompt = (variableKey: string): Question => {
@@ -122,5 +122,5 @@ export const createVariablePrompts: (Prompt | AutoCompletePrompt)[] = [
     namePrompt,
     descriptionPrompt,
     variableTypePrompt,
-    featurePrompt
+    variableFeaturePrompt
 ]

--- a/src/utils/reportValidationErrors.ts
+++ b/src/utils/reportValidationErrors.ts
@@ -1,4 +1,6 @@
 import { ValidationError } from 'class-validator'
+import { ZodError } from 'zod'
+import Writer from '../ui/writer'
 
 export function reportValidationErrors(errors: ValidationError[]): void {
     if (errors.length) {
@@ -9,5 +11,12 @@ export function reportValidationErrors(errors: ValidationError[]): void {
 
         throw new Error(`Failed validation at property "${error.property}": ` +
             `${Object.values(error.constraints ?? {})[0]}`)
+    }
+}
+
+export function reportZodValidationErrors(error: ZodError, writer: Writer): void {
+    const errorsByKey = error.flatten().fieldErrors
+    for (const issues of Object.values(errorsByKey)) {
+        issues?.[0] && writer.showError(issues[0])        
     }
 }


### PR DESCRIPTION
swapped out CreateVariableParams for CreateVariableDto and UpdateVariableDto from the zod schema

also updated the error messages so that it shows `___ is a required field` if the field is missing and can also handle min and max length, and mismatched enums. 
<img width="434" alt="image" src="https://github.com/DevCycleHQ/cli/assets/25067948/f3eadbc6-5c0b-4eab-884f-ba537ec74843">

unfortunately zod doesn't give you access to the failing regex if it's a regex issue, so the best i could do is log `format of ___ is invalid`
<img width="321" alt="image" src="https://github.com/DevCycleHQ/cli/assets/25067948/68a4a267-294b-4f7c-b5b6-0330fe233598">
