### PR TITLE
add generic catch to base command class

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -87,6 +87,13 @@ export default abstract class Base extends Command {
     repoConfig: RepoConfigFromFile | null
     writer: Writer = new Writer()
 
+    async catch(error: unknown) {
+        if (error instanceof ZodError) {
+            this.reportZodValidationErrors(error)
+        } else if (error instanceof Error) {
+            this.writer.showError(error.message)
+        }
+    }
     private async authorizeApi(): Promise<void> {
         const { flags } = await this.parse(this.constructor as typeof Base)
 

--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -70,11 +70,13 @@ describe('diff', () => {
                 message: 'Failed auth'
             })
         })
+        .stdout()
         .command(['diff', '--file',
             './test-utils/fixtures/diff/e2e',
             '--client-id', 'client', '--client-secret', 'secret', '--project', 'project'])
-        .catch('Failed to authenticate with the DevCycle API. Check your credentials.')
-        .it('runs with failed api authorization')
+        .it('runs with failed api authorization', (ctx) => {
+            expect(ctx.stdout).to.contain('Failed to authenticate with the DevCycle API. Check your credentials.')
+        })
 
     test
         .stdout()

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -42,18 +42,12 @@ export default class CreateEnvironment extends CreateCommand {
             return
         }
 
-        try {
-            const params = await this.populateParametersWithZod(
-                CreateEnvironmentDto,
-                this.prompts,
-                flags,
-            )
-            const result = await createEnvironment(this.authToken, this.projectKey, params)
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof ZodError) {
-                this.reportZodValidationErrors(e)
-            }
-        }
+        const params = await this.populateParametersWithZod(
+            CreateEnvironmentDto,
+            this.prompts,
+            flags,
+        )
+        const result = await createEnvironment(this.authToken, this.projectKey, params)
+        this.writer.showResults(result)
     }
 }

--- a/src/commands/environments/update.ts
+++ b/src/commands/environments/update.ts
@@ -57,23 +57,17 @@ export default class UpdateEnvironment extends UpdateCommand {
             this.writer.blankLine()
         }
 
-        try {
-            const params = await this.populateParametersWithZod(
-                UpdateEnvironmentDto,
-                this.prompts,
-                flags
-            )
-            const result = await updateEnvironment(
-                this.authToken,
-                this.projectKey,
-                envKey,
-                params
-            )
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof ZodError) {
-                this.reportZodValidationErrors(e)
-            }
-        }
+        const params = await this.populateParametersWithZod(
+            UpdateEnvironmentDto,
+            this.prompts,
+            flags
+        )
+        const result = await updateEnvironment(
+            this.authToken,
+            this.projectKey,
+            envKey,
+            params
+        )
+        this.writer.showResults(result)
     }
 }

--- a/src/commands/features/create.ts
+++ b/src/commands/features/create.ts
@@ -32,37 +32,30 @@ export default class CreateFeature extends CreateCommand {
             return
         }
 
-        try {
-            const params = await this.populateParametersWithZod(CreateFeatureDto, this.prompts, {
-                key,
-                name,
-                description,
-                ...(variables ? { variables: JSON.parse(variables) } : {}),
-                ...(variations ? { variations: JSON.parse(variations) } : {}),
-                ...(sdkVisibility ? { sdkVisibility: JSON.parse(sdkVisibility) } : {}),
-                headless
-            })
-    
-            if (!headless) {
-                if (!variables) {
-                    params.variables = await (new VariableListOptions([], this.writer)).prompt()
-                }
-        
-                // TODO: Add variation prompt
-        
-                if (!params.sdkVisibility) {
-                    params.sdkVisibility = await sdkVisibilityPrompt()
-                }
+        const params = await this.populateParametersWithZod(CreateFeatureDto, this.prompts, {
+            key,
+            name,
+            description,
+            ...(variables ? { variables: JSON.parse(variables) } : {}),
+            ...(variations ? { variations: JSON.parse(variations) } : {}),
+            ...(sdkVisibility ? { sdkVisibility: JSON.parse(sdkVisibility) } : {}),
+            headless
+        })
+
+        if (!headless) {
+            if (!variables) {
+                params.variables = await (new VariableListOptions([], this.writer)).prompt()
             }
-    
-            const result = await createFeature(this.authToken, this.projectKey, params)
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof ZodError) {
-                this.reportZodValidationErrors(e)
-            } else if (e instanceof Error) {
-                this.writer.showError(e.message)
+
+            // TODO: Add variation prompt
+
+            if (!params.sdkVisibility) {
+                params.sdkVisibility = await sdkVisibilityPrompt()
             }
         }
+
+        const result = await createFeature(this.authToken, this.projectKey, params)
+        this.writer.showResults(result)
+
     }
 }

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -30,21 +30,15 @@ export default class CreateVariable extends CreateCommand {
     public async run(): Promise<void> {
         const { flags } = await this.parse(CreateVariable)
         const { key, name, type, feature, headless } = flags
- 
+
         if (headless && (!key || !name || !type || !feature)) {
             this.writer.showError('The key, name, feature, and type flags are required')
             return
         }
         flags._feature = feature
 
-        try {
-            const params = await this.populateParametersWithZod(CreateVariableDto, this.prompts, flags)
-            const result = await createVariable(this.authToken, this.projectKey, params)
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof ZodError) {
-                this.reportZodValidationErrors(e)
-            }
-        }
+        const params = await this.populateParametersWithZod(CreateVariableDto, this.prompts, flags)
+        const result = await createVariable(this.authToken, this.projectKey, params)
+        this.writer.showResults(result)
     }
 }

--- a/src/commands/variables/update.ts
+++ b/src/commands/variables/update.ts
@@ -57,23 +57,17 @@ export default class UpdateVariable extends UpdateCommand {
             this.writer.blankLine()
         }
 
-        try {
-            const params = await this.populateParametersWithZod(
-                UpdateVariableDto,
-                this.prompts,
-                flags,
-            )
-            const result = await updateVariable(
-                this.authToken,
-                this.projectKey,
-                variableKey,
-                params
-            )
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof ZodError) {
-                this.reportZodValidationErrors(e)
-            }
-        }
+        const params = await this.populateParametersWithZod(
+            UpdateVariableDto,
+            this.prompts,
+            flags,
+        )
+        const result = await updateVariable(
+            this.authToken,
+            this.projectKey,
+            variableKey,
+            params
+        )
+        this.writer.showResults(result)
     }
 }

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -77,41 +77,35 @@ export default class UpdateVariation extends UpdateCommand {
         this.writer.statusMessage(JSON.stringify(selectedVariation, null, 2))
         this.writer.blankLine()
 
-        try {
-            const data = await this.populateParameters(UpdateVariationParams, this.prompts, {
-                name,
-                key,
-                ...(variables ? { variables: JSON.parse(variables) } : {}),
-                headless
-            }, true)
-            let variableAnswers: Record<string, unknown> = {}
-            if (!variables && data.variables) {
-                variableAnswers = await getVariationVariableValuePrompts(
-                    featureKey,
-                    // This is a hack that's needed since the output from the variable prompt is different
-                    // from the input for the --variable flag. That variation variable value data comes from
-                    // this prompt.
-                    data.variables as unknown as Variable[],
-                    selectedVariation.variables
-                )
-            }
-
-            const result = await updateVariation(
-                this.authToken,
-                this.projectKey,
+        const data = await this.populateParameters(UpdateVariationParams, this.prompts, {
+            name,
+            key,
+            ...(variables ? { variables: JSON.parse(variables) } : {}),
+            headless
+        }, true)
+        let variableAnswers: Record<string, unknown> = {}
+        if (!variables && data.variables) {
+            variableAnswers = await getVariationVariableValuePrompts(
                 featureKey,
-                selectedVariation.key,
-                {
-                    key: data.key,
-                    name: data.name,
-                    variables: variables ? JSON.parse(variables) : variableAnswers
-                }
+                // This is a hack that's needed since the output from the variable prompt is different
+                // from the input for the --variable flag. That variation variable value data comes from
+                // this prompt.
+                data.variables as unknown as Variable[],
+                selectedVariation.variables
             )
-            this.writer.showResults(result)
-        } catch (e) {
-            if (e instanceof Error) {
-                this.writer.showError(e.message)
-            }
         }
+
+        const result = await updateVariation(
+            this.authToken,
+            this.projectKey,
+            featureKey,
+            selectedVariation.key,
+            {
+                key: data.key,
+                name: data.name,
+                variables: variables ? JSON.parse(variables) : variableAnswers
+            }
+        )
+        this.writer.showResults(result)
     }
 }

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -23,7 +23,7 @@ export abstract class ListOptionsPrompt<T> {
 
     /**
      * Returns the list of possible options for this List
-     * @returns 
+     * @returns
      */
     abstract options(): { name: string, value: string }[]
 
@@ -41,7 +41,7 @@ export abstract class ListOptionsPrompt<T> {
         return response.listPromptOption
     }
 
-    /** 
+    /**
      * Implementation should be prescribed by the specific subclass for adding
      * and editing the list of items
      */
@@ -75,7 +75,7 @@ export abstract class ListOptionsPrompt<T> {
             type: 'list',
             choices: list
         }])
-    
+
         const itemToMoveTo = await inquirer.prompt([{
             name: 'itemNewIndex',
             message: `Select the position you would like to move the ${this.itemType} to:`,
@@ -136,7 +136,7 @@ export abstract class ListOptionsPrompt<T> {
             }
         }
         this.printListOptions(newList)
-    
+
         // keep prompting until they choose to continue with the saved changes to the list
         if (response !== 'continue') {
             return this.prompt(newList)


### PR DESCRIPTION
Override the `catch` function on the `Command` class in the base class.  This will make it so that we dont need to add as much custom error handling in the command methods for things like api errors and zod validation errors