### PR TITLE
Add features update command

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -7,6 +7,7 @@ Access or modify Features with the Management API
 * [`dvc features delete [FEATURE]`](#dvc-features-delete-feature)
 * [`dvc features get`](#dvc-features-get)
 * [`dvc features list`](#dvc-features-list)
+* [`dvc features update [KEY]`](#dvc-features-update-key)
 
 ## `dvc features create`
 
@@ -110,4 +111,34 @@ GLOBAL FLAGS
                               warnings about missing credentials.
   --project=<value>           Project key to use for the DevCycle API requests
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+```
+
+## `dvc features update [KEY]`
+
+Update a Feature.
+
+```
+USAGE
+  $ dvc features update [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--name <value>] [--variables
+    <value>] [--sdkVisibility <value>]
+
+FLAGS
+  --name=<value>           Human readable name
+  --sdkVisibility=<value>  The visibility of the feature for the SDKs
+  --variables=<value>      The variables to create for the feature
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Update a Feature.
 ```

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1538,6 +1538,112 @@
       },
       "args": {}
     },
+    "features:update": {
+      "id": "features:update",
+      "description": "Update a Feature.",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
+        },
+        "name": {
+          "name": "name",
+          "type": "option",
+          "description": "Human readable name",
+          "multiple": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "option",
+          "description": "The variables to create for the feature",
+          "multiple": false
+        },
+        "sdkVisibility": {
+          "name": "sdkVisibility",
+          "type": "option",
+          "description": "The visibility of the feature for the SDKs",
+          "multiple": false
+        }
+      },
+      "args": {
+        "key": {
+          "name": "key"
+        }
+      }
+    },
     "generate:types": {
       "id": "generate:types",
       "description": "Generate Variable Types from the management API",

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios'
 import apiClient from './apiClient'
-import { CreateFeatureParams, Feature } from './schemas'
+import { CreateFeatureParams, Feature, UpdateFeatureParams } from './schemas'
 import 'reflect-metadata'
 import { buildHeaders } from './common'
 
@@ -46,6 +46,21 @@ export const createFeature = async (
         headers: buildHeaders(token),
         params: {
             project: project_id
+        }
+    })
+}
+
+export const updateFeature = async (
+    token: string, 
+    project_id: string,
+    feature_id: string,
+    params: UpdateFeatureParams,
+): Promise<Feature> => {
+    return await apiClient.patch(`${FEATURE_URL}/:key`, params, {
+        headers: buildHeaders(token),
+        params: {
+            project: project_id,
+            key: feature_id
         }
     })
 }

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -18,6 +18,9 @@ export const UpdateEnvironmentDto = schemas.UpdateEnvironmentDto
 export type CreateFeatureParams = z.infer<typeof schemas.CreateFeatureDto>
 export const CreateFeatureDto = schemas.CreateFeatureDto
 
+export type UpdateFeatureParams = z.infer<typeof schemas.UpdateFeatureDto>
+export const UpdateFeatureDto = schemas.UpdateFeatureDto
+
 export type CreateVariableParams = z.infer<typeof schemas.CreateVariableDto>
 export const CreateVariableDto = schemas.CreateVariableDto
 

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -14,7 +14,7 @@ import { promptForProject } from '../ui/promptForProject'
 import inquirer from 'inquirer'
 import Writer from '../ui/writer'
 import { errorMap, setDVCReferrer } from '../api/apiClient'
-import { Prompt } from '../ui/prompts'
+import { Prompt, handleCustomPrompts } from '../ui/prompts'
 import { filterPrompts, mergeFlagsAndAnswers, validateParams } from '../utils/prompts'
 import z, { ZodObject, ZodTypeAny, ZodError } from 'zod'
 
@@ -280,10 +280,7 @@ export default abstract class Base extends Command {
 
     protected async populateParametersWithInquirer(prompts: Prompt[]) {
         if (!prompts.length) return {}
-        return inquirer.prompt(prompts, {
-            token: this.authToken,
-            projectKey: this.projectKey
-        })
+        return handleCustomPrompts(prompts, this.authToken, this.projectKey)
     }
 
     protected reportZodValidationErrors(error: ZodError): void {

--- a/src/commands/features/__snapshots__/update.test.ts.snap
+++ b/src/commands/features/__snapshots__/update.test.ts.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`features update accepts flags and prompts for missing fields 1`] = `
+"
+
+🤖 Current values:
+🤖 {
+  \\"name\\": \\"Feature Name\\",
+  \\"key\\": \\"feature-key\\",
+  \\"_id\\": \\"id\\",
+  \\"_project\\": \\"string\\",
+  \\"source\\": \\"api\\",
+  \\"_createdBy\\": \\"string\\",
+  \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"variations\\": [],
+  \\"variables\\": [],
+  \\"tags\\": [],
+  \\"ldLink\\": \\"string\\",
+  \\"readonly\\": true,
+  \\"sdkVisibility\\": {
+    \\"mobile\\": true,
+    \\"client\\": true,
+    \\"server\\": true
+  }
+}
+
+
+{
+  \\"name\\": \\"Feature Name\\",
+  \\"key\\": \\"feature-key\\",
+  \\"_id\\": \\"id\\",
+  \\"_project\\": \\"string\\",
+  \\"source\\": \\"api\\",
+  \\"_createdBy\\": \\"string\\",
+  \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"variations\\": [],
+  \\"variables\\": [],
+  \\"tags\\": [],
+  \\"ldLink\\": \\"string\\",
+  \\"readonly\\": true,
+  \\"sdkVisibility\\": {
+    \\"mobile\\": true,
+    \\"client\\": true,
+    \\"server\\": true
+  }
+}
+"
+`;
+
+exports[`features update updates a feature after prompting for all fields 1`] = `
+"
+
+🤖 Current values:
+🤖 {
+  \\"name\\": \\"Feature Name\\",
+  \\"key\\": \\"feature-key\\",
+  \\"_id\\": \\"id\\",
+  \\"_project\\": \\"string\\",
+  \\"source\\": \\"api\\",
+  \\"_createdBy\\": \\"string\\",
+  \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"variations\\": [],
+  \\"variables\\": [],
+  \\"tags\\": [],
+  \\"ldLink\\": \\"string\\",
+  \\"readonly\\": true,
+  \\"sdkVisibility\\": {
+    \\"mobile\\": true,
+    \\"client\\": true,
+    \\"server\\": true
+  }
+}
+
+
+{
+  \\"name\\": \\"Feature Name\\",
+  \\"key\\": \\"feature-key\\",
+  \\"_id\\": \\"id\\",
+  \\"_project\\": \\"string\\",
+  \\"source\\": \\"api\\",
+  \\"_createdBy\\": \\"string\\",
+  \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
+  \\"variations\\": [],
+  \\"variables\\": [],
+  \\"tags\\": [],
+  \\"ldLink\\": \\"string\\",
+  \\"readonly\\": true,
+  \\"sdkVisibility\\": {
+    \\"mobile\\": true,
+    \\"client\\": true,
+    \\"server\\": true
+  }
+}
+"
+`;
+
+exports[`features update updates a feature in headless mode 1`] = `
+"{\\"name\\":\\"Feature Name\\",\\"key\\":\\"feature-key\\",\\"_id\\":\\"id\\",\\"_project\\":\\"string\\",\\"source\\":\\"api\\",\\"_createdBy\\":\\"string\\",\\"createdAt\\":\\"2019-08-24T14:15:22Z\\",\\"updatedAt\\":\\"2019-08-24T14:15:22Z\\",\\"variations\\":[],\\"variables\\":[],\\"tags\\":[],\\"ldLink\\":\\"string\\",\\"readonly\\":true,\\"sdkVisibility\\":{\\"mobile\\":true,\\"client\\":true,\\"server\\":true}}
+"
+`;

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -182,11 +182,7 @@ describe('features create', () => {
             key: requestBody.key, 
             description: undefined, 
             listPromptOption: 'continue',
-            sdkVisibility: {
-                mobile: true,
-                client: true,
-                server: true
-            }
+            sdkVisibility: ['mobile', 'server', 'client']
         }))
         .nock(BASE_URL, (api) => api
             .post(`/v1/projects/${projectKey}/features`, {

--- a/src/commands/features/create.ts
+++ b/src/commands/features/create.ts
@@ -1,10 +1,9 @@
 import { createFeature } from '../../api/features'
-import { descriptionPrompt, keyPrompt, namePrompt, sdkVisibilityPrompt } from '../../ui/prompts'
+import { descriptionPrompt, getSdkVisibilityPrompt, keyPrompt, namePrompt } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
 import { VariableListOptions } from '../../ui/prompts/listPrompts/variablesListPrompt'
 import { Flags } from '@oclif/core'
 import { CreateFeatureDto } from '../../api/schemas'
-import { ZodError } from 'zod'
 
 export default class CreateFeature extends CreateCommand {
     static hidden = false
@@ -32,6 +31,7 @@ export default class CreateFeature extends CreateCommand {
             return
         }
 
+        this.prompts.push(getSdkVisibilityPrompt())     
         const params = await this.populateParametersWithZod(CreateFeatureDto, this.prompts, {
             key,
             name,
@@ -47,11 +47,7 @@ export default class CreateFeature extends CreateCommand {
                 params.variables = await (new VariableListOptions([], this.writer)).prompt()
             }
 
-            // TODO: Add variation prompt
-
-            if (!params.sdkVisibility) {
-                params.sdkVisibility = await sdkVisibilityPrompt()
-            }
+            // TODO: Add variation prompt (DVC-7875)
         }
 
         const result = await createFeature(this.authToken, this.projectKey, params)

--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -1,0 +1,164 @@
+import { expect } from '@oclif/test'
+import { dvcTest, setCurrentTestFile } from '../../../test-utils'
+import { BASE_URL } from '../../api/common'
+import { jestSnapshotPlugin } from 'mocha-chai-jest-snapshot'
+import chai from 'chai'
+import inquirer from 'inquirer'
+
+describe('features update', () => {
+    beforeEach(setCurrentTestFile(__filename))
+    chai.use(jestSnapshotPlugin())
+
+    const projectKey = 'test-project'
+    const authFlags = ['--client-id', 'test-client-id', '--client-secret', 'test-client-secret']
+
+    const testVariables = [
+        {
+            key: 'string-var',
+            type: 'String',
+        }
+    ]
+
+    const mockFeature = {
+        'name': 'Feature Name',
+        'key': 'feature-key',
+        '_id': 'id',
+        '_project': 'string',
+        'source': 'api',
+        '_createdBy': 'string',
+        'createdAt': '2019-08-24T14:15:22Z',
+        'updatedAt': '2019-08-24T14:15:22Z',
+        'variations': [],
+        'variables': [],
+        'tags': [],
+        'ldLink': 'string',
+        'readonly': true,
+        'sdkVisibility': {
+            'mobile': true,
+            'client': true,
+            'server': true
+        }
+    }
+
+    const testSDKVisibility = {
+        mobile: true,
+        client: false,
+        server: true
+    }
+
+    const requestBody = {
+        name: 'New Feature Name',
+        key: 'new-feature-key',
+        description: 'test description',
+        sdkVisibility: testSDKVisibility
+    }
+
+    const requestBodyWithVariables = {
+        ...requestBody,
+        variables: testVariables
+    }
+
+    // headless mode:
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/features`)
+            .reply(200, [mockFeature])
+        )
+        .nock(BASE_URL, (api) => api
+            .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBodyWithVariables)
+            .reply(200, mockFeature)
+        )
+        .stdout()
+        .command([
+            'features update', mockFeature.key,
+            '--project', projectKey,
+            '--name', requestBodyWithVariables.name,
+            '--key', requestBodyWithVariables.key,
+            '--description', requestBody.description,
+            '--variables', JSON.stringify(requestBodyWithVariables.variables),
+            '--sdkVisibility', JSON.stringify(requestBodyWithVariables.sdkVisibility),
+            '--headless',
+            ...authFlags
+        ])
+        .it('updates a feature in headless mode',
+            (ctx) => {
+                expect(ctx.stdout).toMatchSnapshot()
+            }
+        )
+    
+    dvcTest()
+        .stdout()
+        .command([
+            'features update',
+            '--project', projectKey,
+            '--name', requestBodyWithVariables.name,
+            '--key', requestBodyWithVariables.key,
+            '--description', requestBodyWithVariables.description,
+            '--variables', JSON.stringify(requestBodyWithVariables.variables),
+            '--sdkVisibility', JSON.stringify(requestBodyWithVariables.sdkVisibility),
+            '--headless',
+            ...authFlags
+        ])
+        .it('returns an error if key is not provided in headless mode',
+            (ctx) => {
+                expect(ctx.stdout).to.contain('The key argument is required')
+            }
+        )
+
+    // interactive mode:
+    dvcTest()
+        .stub(inquirer, 'prompt', () => ({
+            ...requestBody, 
+            sdkVisibility: ['mobile', 'server'],
+            whichFields: Object.keys(requestBody),
+            listPromptOption: 'continue',
+        }))
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/features`)
+            .reply(200, [mockFeature])
+        )
+        .nock(BASE_URL, (api) => api
+            .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBody)
+            .reply(200, mockFeature)
+        )
+        .stdout()
+        .command([
+            'features update', mockFeature.key,
+            '--project', projectKey,
+            ...authFlags
+        ])
+        .it('updates a feature after prompting for all fields',
+            (ctx) => {
+                expect(ctx.stdout).toMatchSnapshot()
+            }
+        )
+
+    dvcTest()
+        .stub(inquirer, 'prompt', () => ({
+            ...requestBody,
+            name: null,
+            sdkVisibility: ['mobile', 'server'],
+            whichFields: ['key', 'description', 'sdkVisibility'],
+            listPromptOption: 'continue',
+        }))
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/features`)
+            .reply(200, [mockFeature])
+        )
+        .nock(BASE_URL, (api) => api
+            .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBody)
+            .reply(200, mockFeature)
+        )
+        .stdout()
+        .command([
+            'features update', mockFeature.key,
+            '--name', requestBody.name,
+            '--project', projectKey,
+            ...authFlags
+        ])
+        .it('accepts flags and prompts for missing fields',
+            (ctx) => {
+                expect(ctx.stdout).toMatchSnapshot()
+            }
+        )
+})

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -1,0 +1,85 @@
+import { fetchFeatures, updateFeature } from '../../api/features'
+import { 
+    descriptionPrompt, 
+    featurePrompt, 
+    getSdkVisibilityPrompt, 
+    keyPrompt, 
+    namePrompt,
+} from '../../ui/prompts'
+import UpdateCommand from '../updateCommand'
+import { Flags } from '@oclif/core'
+import { Feature, UpdateFeatureDto } from '../../api/schemas'
+import { ZodError } from 'zod'
+import inquirer from '../../ui/autocomplete'
+import { VariableListOptions } from '../../ui/prompts/listPrompts/variablesListPrompt'
+
+export default class UpdateFeature extends UpdateCommand {
+    static hidden = false
+    authRequired = true
+    static description = 'Update a Feature.'
+    static flags = {
+        ...UpdateCommand.flags,
+        variables: Flags.string({
+            description: 'The variables to create for the feature'
+        }),
+        sdkVisibility: Flags.string({
+            description: 'The visibility of the feature for the SDKs'
+        }),
+        key: Flags.string({
+            description: 'The unique key of the feature'
+        }),
+        description: Flags.string({
+            description: 'A description of the feature'
+        }),
+    }
+
+    prompts = [keyPrompt, namePrompt, descriptionPrompt]
+
+    public async run(): Promise<void> {
+        const { flags, args } = await this.parse(UpdateFeature)
+        const { headless, key, name, description, variables, variations, sdkVisibility } = flags
+        await this.requireProject()
+
+        let featureKey = args.key
+        if (headless && !featureKey) {
+            this.writer.showError('The key argument is required')
+            return
+        } else if (!featureKey) {
+            const response = await inquirer.prompt([featurePrompt], {
+                token: this.authToken,
+                projectKey: this.projectKey
+            })
+            featureKey = response.feature
+        }
+        const features = await fetchFeatures(this.authToken, this.projectKey)
+        const feature = features.find((f) => f._id === featureKey || f.key === featureKey)
+
+        if (!feature) {
+            this.writer.showError(`Feature with key ${featureKey} could not be found`)
+            return
+        }
+
+        this.writer.blankLine()
+        this.writer.statusMessage('Current values:')
+        this.writer.statusMessage(JSON.stringify(feature, null, 2))
+        this.writer.blankLine()
+
+        this.prompts.push((new VariableListOptions([], this.writer)).getVariablesListPrompt(feature.variables))
+        this.prompts.push(getSdkVisibilityPrompt(feature))     
+    
+        const params = await this.populateParametersWithZod(UpdateFeatureDto, this.prompts, {
+            key,
+            name,
+            description,
+            ...(variables ? { variables: JSON.parse(variables) } : {}),
+            ...(variations ? { variations: JSON.parse(variations) } : {}),
+            ...(sdkVisibility ? { sdkVisibility: JSON.parse(sdkVisibility) } : {}),
+            headless,
+        })
+
+        // TODO: Add variation prompt (DVC-7875)
+
+        const result = await updateFeature(this.authToken, this.projectKey, feature.key, params)
+        this.writer.showResults(result)  
+    }
+}

--- a/src/commands/updateCommand.ts
+++ b/src/commands/updateCommand.ts
@@ -1,6 +1,6 @@
 import { Args, Flags } from '@oclif/core'
 import Base from './base'
-import { Prompt } from '../ui/prompts'
+import { Prompt, handleCustomPrompts } from '../ui/prompts'
 import inquirer from 'inquirer'
 
 export default abstract class UpdateCommand extends Base {
@@ -22,14 +22,11 @@ export default abstract class UpdateCommand extends Base {
     }
 
     protected async populateParametersWithInquirer(prompts: Prompt[]) {
-        if (!prompts.length) return []
+        if (!prompts.length) return {}
         let filteredPrompts = [ ...prompts ]
         const whichFields = await this.chooseFields(prompts)
         filteredPrompts = prompts.filter((prompt) => whichFields.includes(prompt.name))
-        return inquirer.prompt(filteredPrompts, {
-            token: this.authToken,
-            projectKey: this.projectKey
-        })
+        return handleCustomPrompts(filteredPrompts, this.authToken, this.projectKey)
     }
 
     private async chooseFields(prompts: Prompt[]): Promise<string[]> {

--- a/src/ui/prompts/featurePrompts.ts
+++ b/src/ui/prompts/featurePrompts.ts
@@ -2,7 +2,6 @@ import { PromptResult } from './'
 import { fetchFeatures } from '../../api/features'
 import { Feature } from '../../api/schemas'
 import { autocompleteSearch } from '../autocomplete'
-import inquirer from 'inquirer'
 
 type FeatureChoice = {
     name: string,
@@ -13,7 +12,7 @@ export type FeaturePromptResult = {
     feature: FeatureChoice['value']
 } & PromptResult
 
-let choices: { name: string, value: string }[]
+let choices: FeatureChoice[]
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const featureChoices = async (input: Record<string, any>, search: string): Promise<FeatureChoice[]> => {
     if (!choices) {
@@ -47,42 +46,37 @@ type SDKVisibilityChoice = {
     value: 'mobile' | 'client' | 'server',
     checked: boolean
 }
-type SDKVisibilityPromptResult = {
-    sdkVisibility: SDKVisibilityChoice['value'][]
-}
 
 export const getSDKVisibilityChoices = (sdkVisibility?: Feature['sdkVisibility']): SDKVisibilityChoice[] => {
     return [
         {
             name: 'mobile',
             value: 'mobile',
-            checked: sdkVisibility?.mobile || true
+            checked: typeof sdkVisibility?.mobile !== 'undefined' ? sdkVisibility?.mobile : true
         },
         {
             name: 'client',
             value: 'client',
-            checked: sdkVisibility?.client || true
+            checked: typeof sdkVisibility?.client !== 'undefined' ? sdkVisibility?.client : true
         }, 
         {
             name: 'server',
             value: 'server',
-            checked: sdkVisibility?.server || true
+            checked: typeof sdkVisibility?.server !== 'undefined' ? sdkVisibility?.server : true
         },
     ]
 }
 
-export const sdkVisibilityPrompt = async (
-    sdkVisibility?: Feature['sdkVisibility']
-): Promise<Feature['sdkVisibility']> => {
-    const response = await inquirer.prompt<SDKVisibilityPromptResult>([{
+export const getSdkVisibilityPrompt = (feature?: Feature) => {
+    return {
         name: 'sdkVisibility',
         message: 'Which SDKs should this feature be visible to?',
         type: 'checkbox',
-        choices: getSDKVisibilityChoices(sdkVisibility)
-    }])
-    return {
-        mobile: response.sdkVisibility.includes('mobile'),
-        client: response.sdkVisibility.includes('client'),
-        server: response.sdkVisibility.includes('server')
+        choices: getSDKVisibilityChoices(feature?.sdkVisibility),
+        transformResponse: (response: string[]) => ({
+            mobile: response.includes('mobile'),
+            client: response.includes('client'),
+            server: response.includes('server')    
+        })
     }
 }

--- a/src/ui/prompts/listPrompts/variablesListPrompt.ts
+++ b/src/ui/prompts/listPrompts/variablesListPrompt.ts
@@ -2,7 +2,7 @@ import { createVariablePrompts } from '../variablePrompts'
 import { ListOption, ListOptionsPrompt } from './listOptionsPrompt'
 import inquirer from 'inquirer'
 import { AddItemPrompt, EditItemPrompt, RemoveItemPrompt, ContinuePrompt, ExitPrompt } from './promptOptions'
-import { CreateVariableDto, CreateVariableParams, UpdateVariableDto } from '../../../api/schemas'
+import { CreateVariableDto, CreateVariableParams, UpdateVariableDto, Variable } from '../../../api/schemas'
 import { errorMap } from '../../../api/apiClient'
 
 export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams> {
@@ -20,6 +20,17 @@ export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams>
     }
     variablePropertyPrompts = createVariablePrompts.filter((prompt) => prompt.name !== '_feature')
 
+    getVariablesListPrompt = (existingVariables?: Variable[]) => ({
+        name: 'variables', 
+        value: 'variables', 
+        message: 'Manage variables',
+        type: 'listOptions',
+        listOptionsPrompt: () => this.prompt(existingVariables?.map((variable) => ({
+            name: variable.name || variable.key,
+            value: variable
+        })))
+    })
+ 
     async promptAddItem<CreateVariableParams>(): Promise<ListOption<CreateVariableParams>> {
         const variable = await inquirer.prompt(this.variablePropertyPrompts)
         CreateVariableDto.parse(variable, { errorMap })

--- a/src/ui/prompts/types.ts
+++ b/src/ui/prompts/types.ts
@@ -1,3 +1,5 @@
+import { ListOption } from './listPrompts/listOptionsPrompt'
+
 export type PromptResult = {
   token: string,
   projectKey: string
@@ -9,7 +11,14 @@ export type Prompt = {
     type: string
     suffix?: string
     transformer?: (value: string, answers: any, { isFinal }: { isFinal: boolean }) => string
-    choices?: unknown[]
+    choices?: unknown[],
+    transformResponse?: (response: any) => any
+    listOptionsPrompt?: (list?: ListOption<any>[]) => Promise<any>
+}
+
+export type ListPrompt = Prompt & {
+  type: 'listOptions',
+  listOptionsPrompt: (list?: ListOption<any>[]) => Promise<any>
 }
 
 export type AutoCompletePrompt = Prompt & {


### PR DESCRIPTION
![inquirer-autocomplete-prompt2](https://github.com/DevCycleHQ/cli/assets/25067948/bc38c859-d3a9-4521-99e8-90ac7608801a)

In order to be able to include the variables and sdkVisibility prompts in the update choices list and only prompt for them if they're selected, i had to make these changes:
- changed `sdkVisibilityPrompt` to `getSdkVisibilityPrompt` which returns a prompt we can include in the prompt lists instead of wrapping around the prompt function directly
- added `transformResponse` function to Prompt type to handle transforming the response from the prompt (because sdkVisibility has to be transformed from an array to an object)
- added `listOptionsPrompt` function to Prompt type to bypass calling inquirer.prompt directly and instead call a custom prompt wrapper (to trigger the VariationListOptions flow)
- created `handleCustomPrompts` function that decides whether to call `inquirer.prompt` or `listOptionsPrompt` for each prompt, and then transforms the response with transformResponse (this is called in `populateParametersWithInquirer`)



