### PR TITLE
Prompt for variations in features create / update:

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -17,13 +17,14 @@ Create a new Feature.
 USAGE
   $ dvc features create [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--key <value>] [--name <value>]
-    [--variables <value>] [--sdkVisibility <value>]
+    [--variables <value>] [--variations <value>] [--sdkVisibility <value>]
 
 FLAGS
   --key=<value>            Unique ID
   --name=<value>           Human readable name
   --sdkVisibility=<value>  The visibility of the feature for the SDKs
   --variables=<value>      The variables to create for the feature
+  --variations=<value>     The variations to set for the feature
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file
@@ -121,12 +122,15 @@ Update a Feature.
 USAGE
   $ dvc features update [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--name <value>] [--variables
-    <value>] [--sdkVisibility <value>]
+    <value>] [--variations <value>] [--sdkVisibility <value>] [--key <value>] [--description <value>]
 
 FLAGS
+  --description=<value>    A description of the feature
+  --key=<value>            The unique key of the feature
   --name=<value>           Human readable name
   --sdkVisibility=<value>  The visibility of the feature for the SDKs
-  --variables=<value>      The variables to create for the feature
+  --variables=<value>      The variables to set for the feature
+  --variations=<value>     The variations to set for the feature
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1264,6 +1264,12 @@
           "description": "The variables to create for the feature",
           "multiple": false
         },
+        "variations": {
+          "name": "variations",
+          "type": "option",
+          "description": "The variations to set for the feature",
+          "multiple": false
+        },
         "sdkVisibility": {
           "name": "sdkVisibility",
           "type": "option",
@@ -1628,13 +1634,31 @@
         "variables": {
           "name": "variables",
           "type": "option",
-          "description": "The variables to create for the feature",
+          "description": "The variables to set for the feature",
+          "multiple": false
+        },
+        "variations": {
+          "name": "variations",
+          "type": "option",
+          "description": "The variations to set for the feature",
           "multiple": false
         },
         "sdkVisibility": {
           "name": "sdkVisibility",
           "type": "option",
           "description": "The visibility of the feature for the SDKs",
+          "multiple": false
+        },
+        "key": {
+          "name": "key",
+          "type": "option",
+          "description": "The unique key of the feature",
+          "multiple": false
+        },
+        "description": {
+          "name": "description",
+          "type": "option",
+          "description": "A description of the feature",
           "multiple": false
         }
       },

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -29,3 +29,5 @@ export const UpdateVariableDto = schemas.UpdateVariableDto
 
 export type CreateVariationParams = z.infer<typeof schemas.FeatureVariationDto>
 export const CreateVariationDto = schemas.FeatureVariationDto
+
+export type UpdateVariationParams = Partial<CreateVariationParams>

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -144,6 +144,7 @@ describe('features create', () => {
             key: undefined,
             name: 'new name',
             description: undefined,
+            listPromptOption: 'continue',
         }))
         .stdout()
         .command([
@@ -163,6 +164,7 @@ describe('features create', () => {
             key: 'new-key',
             name: undefined,
             description: undefined,
+            listPromptOption: 'continue',
         }))
         .stdout()
         .command([
@@ -188,6 +190,7 @@ describe('features create', () => {
             .post(`/v1/projects/${projectKey}/features`, {
                 ...requestBody,
                 variables: [],
+                variations: [],
                 sdkVisibility: {
                     mobile: true,
                     client: true,

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -7,9 +7,8 @@ import {
 } from '../../ui/prompts'
 import CreateCommand from '../createCommand'
 import { CreateVariationDto } from '../../api/schemas'
-import { ZodError } from 'zod'
 import { createVariation } from '../../api/variations'
-import { getVariationVariableValuePrompts } from '../../ui/prompts/variationPrompts'
+import { promptForVariationVariableValues } from '../../ui/prompts/variationPrompts'
 import { fetchVariables } from '../../api/variables'
 
 export default class CreateVariation extends CreateCommand {
@@ -67,8 +66,7 @@ export default class CreateVariation extends CreateCommand {
         let variableAnswers: Record<string, unknown> = {}
         if (!variables) {
             const variablesForFeature = await fetchVariables(this.authToken, this.projectKey, featureKey)
-            variableAnswers = await getVariationVariableValuePrompts(
-                featureKey,
+            variableAnswers = await promptForVariationVariableValues(
                 variablesForFeature
             )
         }

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -6,7 +6,7 @@ import { Variable } from '../../api/schemas'
 
 import {
     getVariationVariablePrompt,
-    getVariationVariableValuePrompts,
+    promptForVariationVariableValues,
     variationPrompt,
 } from '../../ui/prompts/variationPrompts'
 import { Args, Flags } from '@oclif/core'
@@ -85,8 +85,7 @@ export default class UpdateVariation extends UpdateCommand {
         }, true)
         let variableAnswers: Record<string, unknown> = {}
         if (!variables && data.variables) {
-            variableAnswers = await getVariationVariableValuePrompts(
-                featureKey,
+            variableAnswers = await promptForVariationVariableValues(
                 // This is a hack that's needed since the output from the variable prompt is different
                 // from the input for the --variable flag. That variation variable value data comes from
                 // this prompt.

--- a/src/ui/prompts/commonPrompts.ts
+++ b/src/ui/prompts/commonPrompts.ts
@@ -58,7 +58,9 @@ export const handleCustomPrompts = async (prompts: Prompt[], authToken: string, 
         projectKey: projectKey
     })
     for (const prompt of listOptionsPrompts as ListPrompt[]) {
-        result[prompt.name] = await prompt.listOptionsPrompt()
+        const carryForward: Record<string, any> = {}
+        prompt.previousReponseFields?.forEach((field) => carryForward[field] = result[field])
+        result[prompt.name] = await prompt.listOptionsPrompt(carryForward)
     }
 
     return transformResponse(result, prompts)

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -45,15 +45,15 @@ export abstract class ListOptionsPrompt<T> {
      * Implementation should be prescribed by the specific subclass for adding
      * and editing the list of items
      */
-    abstract promptAddItem<T>(): Promise<ListOption<T>>
-    abstract promptEditItem<T>(list: ListOption<T>[]): void
+    abstract promptAddItem(): Promise<ListOption<T>>
+    abstract promptEditItem(list: ListOption<T>[]): void
 
     /**
      * Returns a list of indices to remove from the list
      * @param ListOption<T>[]
      * @returns number[]
      */
-    async promptDeleteItems<T>(list: ListOption<T>[]): Promise<number[]> {
+    async promptDeleteItems(list: ListOption<T>[]): Promise<number[]> {
         const responses = await inquirer.prompt([{
             name: 'itemsToDelete',
             message: `Select the ${this.itemType} you would like to delete:`,
@@ -68,7 +68,7 @@ export abstract class ListOptionsPrompt<T> {
      * @param ListOption<T>[]
      * @returns [number, number]
      */
-    async promptReorderItem<T>(list: ListOption<T>[]) {
+    async promptReorderItem(list: ListOption<T>[]) {
         const itemToMove = await inquirer.prompt([{
             name: 'itemToReorder',
             message: `Select the ${this.itemType} you would like to move:`,
@@ -97,7 +97,7 @@ export abstract class ListOptionsPrompt<T> {
      * @param ListOption<T>[]
      * @returns T[]
      */
-    async prompt<T>(list?: ListOption<T>[]): Promise<T[]> {
+    async prompt(list?: ListOption<T>[]): Promise<T[]> {
         const newList = [...(list || this.list)] as ListOption<T>[]
 
         // if there's no list passed in, this should be the first prompt call and thus we should print the list
@@ -148,7 +148,7 @@ export abstract class ListOptionsPrompt<T> {
      * Prints the list of human-readable names of the list to the console
      * @param ListOption<T>[]
      */
-    async printListOptions<T>(list?: ListOption<T>[]) {
+    async printListOptions(list?: ListOption<T>[]) {
         const listToPrint = list || this.list
         this.writer.statusMessage(`Current ${this.itemType}s:`)
         this.writer.list(listToPrint.map((item) => item.name))

--- a/src/ui/prompts/listPrompts/variationsListPrompt.ts
+++ b/src/ui/prompts/listPrompts/variationsListPrompt.ts
@@ -1,5 +1,8 @@
 
-import { CreateVariationParams } from '../../../api/schemas'
+import { errorMap } from '../../../api/apiClient'
+import { CreateVariationDto, CreateVariationParams, Variable, Variation } from '../../../api/schemas'
+import inquirer from '../../autocomplete'
+import { getVariationVariablesPrompts, staticCreateVariationPrompts } from '../variationPrompts'
 import { ListOption, ListOptionsPrompt } from './listOptionsPrompt'
 import { AddItemPrompt, EditItemPrompt, RemoveItemPrompt, ContinuePrompt, ExitPrompt } from './promptOptions'
 
@@ -16,19 +19,74 @@ export class VariationListOptions extends ListOptionsPrompt<CreateVariationParam
             ExitPrompt
         ]
     }
-    async promptAddItem<CreateVariationParams>(): Promise<ListOption<CreateVariationParams>> {
-        // TODO: Implement add item
+
+    featureVariables: Variable[] = []
+
+    getVariationListPrompt = (existingVariations?: Variation[], existingVariables?: Variable[]) => {
+        this.featureVariables = existingVariables || []
+
         return {
-            name: 'Placeholder',
-            value: {} as CreateVariationParams
+            name: 'variations', 
+            value: 'variations', 
+            message: 'Manage variations',
+            type: 'listOptions',
+            previousReponseFields: ['variables'], // if variables were just created / updated, use the new variables
+            listOptionsPrompt: (previousResponses?: Record<string, any>) => {
+                const newVariables = previousResponses?.variables
+                this.featureVariables = newVariables || this.featureVariables
+
+                return this.prompt(existingVariations?.map((variation) => ({
+                    name: variation.name || variation.key,
+                    value: variation
+                })))
+            }
         }
     }
 
-    async promptEditItem<CreateVariationParams>(
+    async promptAddItem() {
+        const variation = await inquirer.prompt(staticCreateVariationPrompts)
+        variation.variables = await inquirer.prompt(getVariationVariablesPrompts(this.featureVariables))
+
+        return {
+            name: variation.name,
+            value: variation
+        }
+    }
+
+    async promptEditItem(
         list: ListOption<CreateVariationParams>[]
-    ): Promise<ListOption<CreateVariationParams>> {
-        // TODO: Implement edit item
-        return Promise.resolve(list[0])
+    ) {
+        if (list.length === 0) {
+            this.writer.warningMessage('No variations to edit')
+            return
+        }
+        const response = await inquirer.prompt([{
+            name: 'variationToEdit',
+            message: 'Which variation would you like to edit?',
+            type: 'list',
+            choices: list
+        }])
+        const index = list.findIndex((listItem) => listItem.value.key === response.variationToEdit.key)
+
+        // Have a default for each of the prompts that correspond to the previous value of the variable
+        const filledOutPrompts = staticCreateVariationPrompts.map((prompt) => ({
+            ...prompt,
+            default: response.variationToEdit[prompt.name]
+        }))
+
+        const editedVariation = await inquirer.prompt(filledOutPrompts)
+        editedVariation.variables = await inquirer.prompt(
+            getVariationVariablesPrompts(this.featureVariables, response.variationToEdit.variables)
+        )
+
+        CreateVariationDto.parse(editedVariation, { errorMap })
+        if (index >= 0) {
+            list[index] = {
+                name: editedVariation.name || editedVariation.key,
+                value: editedVariation
+            }
+        }
+
     }
 
     transformToListOptions(list: CreateVariationParams[]): ListOption<CreateVariationParams>[] {

--- a/src/ui/prompts/types.ts
+++ b/src/ui/prompts/types.ts
@@ -10,15 +10,19 @@ export type Prompt = {
     message: string
     type: string
     suffix?: string
+    default?: unknown
+    filter?: (input:string) => string | number
+    validate?: (input: string) => boolean | string
     transformer?: (value: string, answers: any, { isFinal }: { isFinal: boolean }) => string
     choices?: unknown[],
     transformResponse?: (response: any) => any
-    listOptionsPrompt?: (list?: ListOption<any>[]) => Promise<any>
+    listOptionsPrompt?: (previousResponses?: Record<string, any>) => Promise<any>
 }
 
 export type ListPrompt = Prompt & {
   type: 'listOptions',
-  listOptionsPrompt: (list?: ListOption<any>[]) => Promise<any>
+  listOptionsPrompt: (previousResponses?: Record<string, any>) => Promise<any>
+  previousReponseFields?: string[]
 }
 
 export type AutoCompletePrompt = Prompt & {

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -51,15 +51,16 @@ export const variableTypePrompt = {
     choices: CreateVariableDto.shape.type.options
 }
 
-export const variableValueStringPrompt = (variableKey: string, defaultValue?: string): Question => {
+export const variableValueStringPrompt = (variableKey: string, defaultValue?: string): Prompt => {
     return {
         name: variableKey,
         default:  defaultValue,
+        type: 'input',
         message: `Variable value for ${variableKey}`,
     }
 }
 
-export const variableValueNumberPrompt = (variableKey: string, defaultValue?: number): Question => {
+export const variableValueNumberPrompt = (variableKey: string, defaultValue?: number): Prompt => {
     return {
         name: variableKey,
         message: `Variable value for ${variableKey}`,
@@ -81,7 +82,7 @@ export const variableValueNumberPrompt = (variableKey: string, defaultValue?: nu
     }
 }
 
-export const variableValueBooleanPrompt  = (variableKey: string, defaultValue?: boolean): ListQuestion => {
+export const variableValueBooleanPrompt  = (variableKey: string, defaultValue?: boolean): Prompt => {
     return {
         name: variableKey,
         message: `Variable value for ${variableKey}`,
@@ -100,7 +101,7 @@ export const variableValueBooleanPrompt  = (variableKey: string, defaultValue?: 
     }
 }
 
-export const variableValueJSONPrompt  = (variableKey: string, defaultValue?: string): Question => {
+export const variableValueJSONPrompt  = (variableKey: string, defaultValue?: string): Prompt => {
     return {
         name: variableKey,
         message: `Variable value for ${variableKey}`,

--- a/src/ui/prompts/variationPrompts.ts
+++ b/src/ui/prompts/variationPrompts.ts
@@ -1,7 +1,7 @@
 import { Variation } from '../../api/schemas'
 import { fetchVariations } from '../../api/variations'
 import { fetchVariables } from '../../api/variables'
-import { Prompt } from '../../ui/prompts'
+import { Prompt, keyPrompt, namePrompt } from '../../ui/prompts'
 import { Variable } from '../../api/schemas'
 
 import {
@@ -10,16 +10,11 @@ import {
     variableValueNumberPrompt,
     variableValueStringPrompt
 } from './variablePrompts'
-import inquirer, { Answers, ListQuestion, Question } from 'inquirer'
+import inquirer, { Answers } from 'inquirer'
 
 type VariationChoice = {
     name: string,
     value: Variation
-}
-
-type VariableChoice = {
-    name: string,
-    value: Record<string, unknown>
 }
 
 export const variationChoices = async (input: Record<string, any>):Promise<VariationChoice[]> => {
@@ -63,11 +58,10 @@ export const variationPrompt = {
     choices: variationChoices
 }
 
-export async function getVariationVariableValuePrompts(
-    featureKey: string,
+export function getVariationVariablesPrompts(
     variables: Variable[],
     defaultValues: Record<string, boolean | string | number> = {}
-): Promise<Answers> {
+) {
     const variablePrompts = []
     for (const variable of variables) {
         switch (variable.type) {
@@ -92,6 +86,14 @@ export async function getVariationVariableValuePrompts(
                 )
         }
     }
+    return variablePrompts
+}
+
+export async function promptForVariationVariableValues(
+    variables: Variable[],
+    defaultValues: Record<string, boolean | string | number> = {}
+): Promise<Answers> {
+    const variablePrompts = getVariationVariablesPrompts(variables, defaultValues)
     const promptAnswers = await inquirer.prompt(variablePrompts, {})
     const variableAnswers: Answers = {}
     for (const [key, value] of Object.entries(promptAnswers)) {
@@ -101,3 +103,8 @@ export async function getVariationVariableValuePrompts(
     }
     return variableAnswers
 }
+
+export const staticCreateVariationPrompts: Prompt[] = [
+    keyPrompt,
+    namePrompt,
+]


### PR DESCRIPTION
- added the add/edit functions in VariationsListPrompt
- renamed `getVariationVariableValuePrompts` to `promptForVariationVariableValues` and created a new variationPrompt `getVariationVariablesPrompts` that just returns the prompts without calling inquirer.prompt (so we can use it in the prompts lists)
- added the option to set `previousReponseFields` on listOptions prompt types, which lets us pass previous responses along to the list fields. This way if you add or edit variables, the updated variables list is available in the variations prompt 

features create:
![inquirer-autocomplete-prompt3](https://github.com/DevCycleHQ/cli/assets/25067948/217b4c2e-d32f-47be-beb9-1fd09f183d5f)

features update:
![inquirer-autocomplete-prompt4](https://github.com/DevCycleHQ/cli/assets/25067948/93ec9861-c939-49b0-8ac8-d14fbf7e61cb)

