### PR TITLE
feat: made features create command a quick create, added interactive mode

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -17,9 +17,10 @@ Create a new Feature.
 USAGE
   $ dvc features create [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--key <value>] [--name <value>]
-    [--variables <value>] [--variations <value>] [--sdkVisibility <value>]
+    [--variables <value>] [--variations <value>] [--sdkVisibility <value>] [-i]
 
 FLAGS
+  -i, --interactive        Interactive Feature Creation Mode
   --key=<value>            Unique ID
   --name=<value>           Human readable name
   --sdkVisibility=<value>  The visibility of the feature for the SDKs

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1275,6 +1275,13 @@
           "type": "option",
           "description": "The visibility of the feature for the SDKs",
           "multiple": false
+        },
+        "interactive": {
+          "name": "interactive",
+          "type": "boolean",
+          "char": "i",
+          "description": "Interactive Feature Creation Mode",
+          "allowNo": false
         }
       },
       "args": {}

--- a/src/api/environments.ts
+++ b/src/api/environments.ts
@@ -1,4 +1,5 @@
 import apiClient from './apiClient'
+import { buildHeaders } from './common'
 import { CreateEnvironmentParams, UpdateEnvironmentParams } from './schemas'
 
 export class APIKey {
@@ -13,10 +14,7 @@ export const createEnvironment = async (
     params: CreateEnvironmentParams
 ) => {
     return apiClient.post('/v1/projects/:project/environments', params, {
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: token,
-        },
+        headers: buildHeaders(token),
         params: { project: project_id }
     })
 }
@@ -28,10 +26,7 @@ export const updateEnvironment = async (
     params: UpdateEnvironmentParams
 ) => {
     return apiClient.patch('/v1/projects/:project/environments/:key', params, {
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: token,
-        },
+        headers: buildHeaders(token),
         params: {
             project: project_id,
             key: environmentKey
@@ -41,10 +36,7 @@ export const updateEnvironment = async (
 
 export const fetchEnvironments = async (token: string, project_id: string) => {
     return apiClient.get('/v1/projects/:project/environments', {
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: token,
-        },
+        headers: buildHeaders(token),
         params: {
             project: project_id
         }
@@ -58,10 +50,7 @@ export const fetchEnvironmentByKey = async (
 ) => {
     try {
         const response = await apiClient.get('/v1/projects/:project/environments/:key', {
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: token,
-            },
+            headers: buildHeaders(token),
             params: {
                 project: project_id,
                 key

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -278,15 +278,22 @@ export default abstract class Base extends Command {
     ): Promise<z.infer<typeof schema>> {
         let input = flags
         if (!flags.headless) {
-            const filteredPrompts = filterPrompts(prompts, flags)
-            const answers = await this.populateParametersWithInquirer(filteredPrompts)
-            input = mergeFlagsAndAnswers(flags, answers)
+            input = await this.populateParametersWithFlags(prompts, flags)
         }
         const parse = schema.parse(
             input,
             { errorMap }
         )
         return parse
+    }
+
+    public async populateParametersWithFlags(
+        prompts: Prompt[],
+        flags: Record<string, unknown>,
+    ) {
+        const filteredPrompts = filterPrompts(prompts, flags)
+        const answers = await this.populateParametersWithInquirer(filteredPrompts)
+        return mergeFlagsAndAnswers(flags, answers)
     }
 
     protected async populateParametersWithInquirer(prompts: Prompt[]) {

--- a/src/commands/environments/create.ts
+++ b/src/commands/environments/create.ts
@@ -17,8 +17,8 @@ export default class CreateEnvironment extends CreateCommand {
     static description = 'Create a new Environment for an existing Feature.'
 
     prompts = [
-        keyPrompt,
         namePrompt,
+        keyPrompt,
         descriptionPrompt,
         environmentTypePrompt,
     ]

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@oclif/test'
 import inquirer from 'inquirer'
 import { dvcTest } from '../../../test-utils'
 import { BASE_URL } from '../../api/common'
+import { mergeQuickFeatureParamsWithAnswers } from '../../utils/features/quickCreateFeatureUtils'
 
 describe('features create', () => {
     const projectKey = 'test-project'
@@ -11,6 +12,24 @@ describe('features create', () => {
         key: 'feature-key',
         description: undefined,
     }
+
+    const mockEnvironments = [
+        {
+            key: 'development',
+            name: 'Development',
+            _id: '647f62ae749bbe90fb222070'
+        },
+        {
+            key: 'staging',
+            name: 'Staging',
+            _id: '637cfe8195279288bc08cb62'
+        },
+        {
+            key: 'production',
+            name: 'Production',
+            _id: '637cfe8195279288bc08cb61'
+        }
+    ]
 
     const mockFeature = {
         'name': 'Feature Name',
@@ -69,6 +88,7 @@ describe('features create', () => {
         .stdout()
         .command([
             'features create',
+            '-i',
             '--name', requestBody.name,
             '--key', requestBody.key,
             '--project', projectKey,
@@ -76,6 +96,33 @@ describe('features create', () => {
             ...authFlags
         ])
         .it('returns a new feature',
+            (ctx) => {
+                expect(JSON.parse(ctx.stdout)).to.eql(mockFeature)
+            })
+
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .post(`/v1/projects/${projectKey}/features`)
+            .reply(200, mockFeature)
+            .get(`/v1/projects/${projectKey}/environments`)
+            .reply(200, mockEnvironments)
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=development`)
+            .reply(200, {})
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=staging`)
+            .reply(200, {})
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=production`)
+            .reply(200, {})
+        )
+        .stdout()
+        .command([
+            'features create',
+            '--name', requestBody.name,
+            '--key', requestBody.key,
+            '--project', projectKey,
+            '--headless',
+            ...authFlags
+        ])
+        .it('returns a new feature with quick create',
             (ctx) => {
                 expect(JSON.parse(ctx.stdout)).to.eql(mockFeature)
             })
@@ -94,6 +141,7 @@ describe('features create', () => {
         .stdout()
         .command([
             'features create',
+            '-i',
             '--name', requestBody.name,
             '--key', requestBody.key,
             '--project', projectKey,
@@ -123,6 +171,7 @@ describe('features create', () => {
         .stdout()
         .command([
             'features create',
+            '-i',
             '--name', requestBody.name,
             '--key', requestBody.key,
             '--project', projectKey,
@@ -214,6 +263,33 @@ describe('features create', () => {
                 // TODO: Use snapshot instead to test the entire output
                 const response = ctx.stdout.substring(ctx.stdout.indexOf('{'), ctx.stdout.lastIndexOf('}') + 1)
                 expect(JSON.parse(response)).to.eql(mockFeature)
+            })
+
+    dvcTest()
+        .stub(inquirer, 'registerPrompt', () => { return })
+        .stub(inquirer, 'prompt', () => ({ ...requestBody, description: 'new desc' }))
+        .nock(BASE_URL, (api) => api
+            .post(`/v1/projects/${projectKey}/features`,
+                mergeQuickFeatureParamsWithAnswers({ ...requestBody, description: 'new desc' }) as any)
+            .reply(200, mockFeature)
+            .get(`/v1/projects/${projectKey}/environments`)
+            .reply(200, mockEnvironments)
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=development`)
+            .reply(200, {})
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=staging`)
+            .reply(200, {})
+            .patch(`/v1/projects/${projectKey}/features/${requestBody.key}/configurations?environment=production`)
+            .reply(200, {})
+        )
+        .stdout()
+        .command([
+            'features create',
+            '--project', projectKey,
+            ...authFlags
+        ])
+        .it('returns a new feature with quick create not in headless mode',
+            (ctx) => {
+                expect(JSON.parse(ctx.stdout)).to.eql(mockFeature)
             })
     
     // dvcTest()

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -150,6 +150,7 @@ describe('features create', () => {
         .command([
             'features create',
             '--project', projectKey,
+            '-i',
             ...authFlags
         ])
         .it('returns an error if key is not provided',
@@ -170,6 +171,7 @@ describe('features create', () => {
         .command([
             'features create',
             '--project', projectKey,
+            '-i',
             ...authFlags
         ])
         .it('returns an error if name is not provided',
@@ -202,6 +204,7 @@ describe('features create', () => {
         .stdout()
         .command([
             'features create',
+            '-i',
             '--project', projectKey,
             '--name', requestBody.name,
             ...authFlags

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -36,7 +36,7 @@ export default class UpdateFeature extends UpdateCommand {
         }),
     }
 
-    prompts = [keyPrompt, namePrompt, descriptionPrompt]
+    prompts = [namePrompt, keyPrompt, descriptionPrompt]
 
     public async run(): Promise<void> {
         const { flags, args } = await this.parse(UpdateFeature)

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -7,7 +7,7 @@ export default class CreateProject extends CreateCommand {
     static hidden = false
     static description = 'Create a new Project'
 
-    prompts = [keyPrompt, namePrompt, descriptionPrompt]
+    prompts = [namePrompt, keyPrompt, descriptionPrompt]
 
     static flags = {
         ...CreateCommand.flags,

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -34,7 +34,7 @@ export default class CreateVariation extends CreateCommand {
         '<%= config.bin %> <%= command.id %> --variables=\'{ "bool-var": true, "num-var": 80, "string-var": "test" }\''
     ]
 
-    prompts = [keyPrompt, namePrompt]
+    prompts = [namePrompt, keyPrompt]
 
     public async run(): Promise<void> {
         await this.requireProject()

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -17,8 +17,8 @@ export default class UpdateVariation extends UpdateCommand {
     static description = 'Update a Variation.'
 
     prompts = [
-        keyPrompt,
-        namePrompt
+        namePrompt,
+        keyPrompt
     ]
 
     static args = {

--- a/src/ui/prompts/commonPrompts.ts
+++ b/src/ui/prompts/commonPrompts.ts
@@ -20,7 +20,12 @@ export const keyPrompt: Prompt = {
     name: 'key',
     message: 'Key',
     suffix: ':',
-    transformer: hintTextTransformer('(Unique ID)'),
+    default: (answers: Record<string, string>) => {
+        if (answers.name) {
+            return answers.name.trim().replace(/\s+/g, '-').toLowerCase()
+        }
+        return ''
+    },
     type: 'input'
 }
 

--- a/src/ui/prompts/commonPrompts.ts
+++ b/src/ui/prompts/commonPrompts.ts
@@ -24,7 +24,7 @@ export const keyPrompt: Prompt = {
         if (answers.name) {
             return answers.name.trim().replace(/\s+/g, '-').toLowerCase()
         }
-        return ''
+        return
     },
     type: 'input'
 }

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -126,8 +126,8 @@ export const variableValueJSONPrompt = (variableKey: string, defaultValue?: stri
 }
 
 export const createVariablePrompts: (Prompt | AutoCompletePrompt)[] = [
-    keyPrompt,
     namePrompt,
+    keyPrompt,
     descriptionPrompt,
     variableTypePrompt,
     variableFeaturePrompt

--- a/src/ui/prompts/variationPrompts.ts
+++ b/src/ui/prompts/variationPrompts.ts
@@ -108,6 +108,6 @@ export async function promptForVariationVariableValues(
 }
 
 export const staticCreateVariationPrompts: Prompt[] = [
-    keyPrompt,
     namePrompt,
+    keyPrompt
 ]

--- a/src/utils/features/quickCreateFeatureUtils.ts
+++ b/src/utils/features/quickCreateFeatureUtils.ts
@@ -1,0 +1,64 @@
+import { fetchEnvironments } from '../../api/environments'
+import { CreateFeatureParams } from '../../api/schemas'
+import { updateFeatureConfigForEnvironment } from '../../api/targeting'
+
+// Default variations and variables depending on the key and name provided for quick create
+export const mergeQuickFeatureParamsWithAnswers = (answers: Record<string, string>): CreateFeatureParams => {
+    return {
+        name: answers.name,
+        key: answers.key,
+        description: answers.description,
+        variables: [ 
+            { 
+                name: answers.name, 
+                key: answers.key, 
+                type: 'Boolean' 
+            } 
+        ],
+        variations: [
+            { 
+                key: 'variation-on', 
+                name: 'Variation On', 
+                variables: { [answers.key]: true }
+            },
+            {
+                key: 'variation-off',
+                name: 'Variation Off',
+                variables: { [answers.key]: false }
+            }
+        ],
+    }
+}
+
+// Setup targeting for all environments and turn on development only
+export const setupTargetingForEnvironments = async (
+    authToken: string, 
+    projectKey: string,
+    featureKey: string
+) => {
+    const environments = await fetchEnvironments(authToken, projectKey)
+    await Promise.all(environments.map((environment) => updateFeatureConfigForEnvironment(
+        authToken, 
+        projectKey, 
+        featureKey, 
+        environment.key, {
+            targets: [{
+                distribution: [{
+                    percentage: 1,
+                    _variation: 'variation-on',
+                }],
+                audience: {
+                    name: 'All Users',
+                    filters: {
+                        filters: [
+                            {
+                                type: 'all'
+                            }
+                        ],
+                        operator: 'and'
+                    }
+                }
+            }],
+            status: environment.key === 'development' ? 'active' : 'inactive'
+        })))
+}


### PR DESCRIPTION
# Summary

Made the default behaviour of `features create` to only prompt name, key, description and then use presets for `variables`, `variations`, and `targeting` to make it more seamlined.