### PR TITLE
feat: Display targeting as tree in update command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,4 +14,4 @@ jobs:
         node-version: '18.16.0'
     - run: yarn install
     - run: yarn build
-    - run: yarn test
+    - run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest && oclif readme --multi",
-    "test": "mocha --forbid-only \"test/**/*.test.ts\" \"src/**/*.test.ts\"",
+    "test": "mocha \"src/**/*.test.ts\"",
+    "test:ci": "yarn test --forbid-only",
     "version": "oclif readme --multi && git add README.md",
     "build:watch": "watch 'yarn build' src"
   },

--- a/src/commands/targeting/__snapshots__/update.test.ts.snap
+++ b/src/commands/targeting/__snapshots__/update.test.ts.snap
@@ -1,64 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Targeting update updates a target by adding a filter in interactive mode 1`] = `
+exports[`targeting update updates a target by adding a filter in interactive mode 1`] = `
 "🤖 Current Targeting Rules:
-All Users
+└─ 1. All Users
+   ├─ definition
+   │  └─ All Users
+   └─ serve
+      └─ Variation On
 ----------------------------------------
 🤖 Current Filters:
-{\\"type\\":\\"all\\"}
+└─ All Users
 ----------------------------------------
 🤖 Current Filters:
-{\\"type\\":\\"all\\"}
-
-{\\"type\\":\\"user\\",\\"subType\\":\\"user_id\\",\\"comparator\\":\\"=\\",\\"values\\":[\\"not shrek\\"]}
+├─ All Users
+└─ AND User ID
+   └─ is
+      └─ not shrek
 ----------------------------------------
 🤖 Current Filters:
-{\\"type\\":\\"all\\"}
-
-{\\"type\\":\\"user\\",\\"subType\\":\\"user_id\\",\\"comparator\\":\\"=\\",\\"values\\":[\\"not shrek\\"]}
+├─ All Users
+└─ AND User ID
+   └─ is
+      └─ not shrek
 ----------------------------------------
 🤖 Current Targeting Rules:
-All Users New
+└─ 1. All Users New
+   ├─ definition
+   │  ├─ All Users
+   │  └─ AND User ID
+   │     └─ is
+   │        └─ not shrek
+   └─ serve
+      └─ variation-off
 ----------------------------------------
 🤖 Current Targeting Rules:
-All Users New
+└─ 1. All Users New
+   ├─ definition
+   │  ├─ All Users
+   │  └─ AND User ID
+   │     └─ is
+   │        └─ not shrek
+   └─ serve
+      └─ variation-off
 ----------------------------------------
-{
-  \\"_feature\\": \\"647e36gg16d9k4815fi3f97d\\",
-  \\"_environment\\": \\"648b421gg3f682869c0f22f8\\",
-  \\"_createdBy\\": \\"test\\",
-  \\"status\\": \\"inactive\\",
-  \\"updatedAt\\": \\"2023-06-27T03:19:58.541Z\\",
-  \\"targets\\": [
-    {
-      \\"distribution\\": [
-        {
-          \\"_variation\\": \\"variation-off\\",
-          \\"percentage\\": 1
-        }
-      ],
-      \\"audience\\": {
-        \\"name\\": \\"All Users New\\",
-        \\"filters\\": {
-          \\"filters\\": [
-            {
-              \\"type\\": \\"all\\"
-            },
-            {
-              \\"type\\": \\"user\\",
-              \\"subType\\": \\"user_id\\",
-              \\"comparator\\": \\"=\\",
-              \\"values\\": [
-                \\"not shrek\\"
-              ]
-            }
-          ],
-          \\"operator\\": \\"and\\"
-        }
-      }
-    }
-  ]
-}
+└─ test-env
+   ├─ status
+   │  └─ disabled
+   └─ rules
+      └─ 1. All Users New
+         ├─ definition
+         │  ├─ All Users
+         │  └─ AND User ID
+         │     └─ is
+         │        └─ not shrek
+         └─ serve
+            └─ variation-off
 
 To enable this feature on this environment, use:
 
@@ -67,7 +63,7 @@ To enable this feature on this environment, use:
 "
 `;
 
-exports[`Targeting update updates a target in headless mode 1`] = `
+exports[`targeting update updates a target in headless mode 1`] = `
 "{\\"_feature\\":\\"647e36gg16d9k4815fi3f97d\\",\\"_environment\\":\\"648b421gg3f682869c0f22f8\\",\\"_createdBy\\":\\"test\\",\\"status\\":\\"inactive\\",\\"updatedAt\\":\\"2023-06-27T03:19:58.541Z\\",\\"targets\\":[{\\"_id\\":\\"647e36gg16d9k2814fc3f15e\\",\\"audience\\":{\\"name\\":\\"All Users\\",\\"filters\\":{\\"operator\\":\\"and\\",\\"filters\\":[{\\"type\\":\\"all\\"}]}},\\"distribution\\":[{\\"_variation\\":\\"647e36gg16c1d4814fe3f962\\",\\"percentage\\":1}]}],\\"readonly\\":false}
 "
 `;

--- a/src/ui/prompts/listPrompts/filterListPrompt.ts
+++ b/src/ui/prompts/listPrompts/filterListPrompt.ts
@@ -13,6 +13,7 @@ import { Filter } from '../../../api/schemas'
 import { Prompt } from '../types'
 import { chooseFields } from '../../../utils/prompts'
 import { UserSubType } from '../../../api/targeting'
+import { renderDefinitionTree } from '../../targetingTree'
 
 export class FilterListOptions extends ListOptionsPrompt<Filter> {
     itemType = 'Filter'
@@ -165,5 +166,13 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
             return [filterDataKeyPrompt, filterDataKeyTypePrompt]
         }
         return []
+    }
+
+    async printListOptions(list?: ListOption<Filter>[]) {
+        const listToPrint = list || this.list
+        this.writer.statusMessage(`Current ${this.itemType}s:`)
+        const values = listToPrint.map((item) => item.value.item)
+        renderDefinitionTree(values)
+        this.writer.divider()
     }
 }

--- a/src/ui/prompts/listPrompts/targetingListPrompt.ts
+++ b/src/ui/prompts/listPrompts/targetingListPrompt.ts
@@ -9,9 +9,10 @@ import {
     ReorderItemPrompt
 } from './promptOptions'
 import { servePrompt, audienceNamePrompt } from '../targetingPrompts'
-import { Filters, UpdateTargetParams } from '../../../api/schemas'
+import { Filters, UpdateTargetParams, Variation } from '../../../api/schemas'
 import { FilterListOptions } from './filterListPrompt'
 import Writer from '../../writer'
+import { renderRulesTree } from '../../targetingTree'
 
 export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> {
     itemType = 'Targeting Rule'
@@ -19,6 +20,8 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
     authToken: string
     projectKey: string
     featureKey: string
+
+    variations: Variation[] = []
 
     constructor(list: UpdateTargetParams[], writer: Writer, authToken: string, projectKey: string, featureKey: string) {
         super(list, writer)
@@ -107,5 +110,13 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
             name: target.audience.name || target.name || `Targeting Rule ${index + 1}`,
             value: { item: target, id: index }
         }))
+    }
+
+    async printListOptions(list?: ListOption<UpdateTargetParams>[]) {
+        const listToPrint = list || this.list
+        this.writer.statusMessage(`Current ${this.itemType}s:`)
+        const values = listToPrint.map((item) => item.value.item)
+        renderRulesTree(values, this.variations)
+        this.writer.divider()
     }
 }


### PR DESCRIPTION
- Update `targeting update` output to display tree when not in headless mode
- Update targeting list prompts to display current targeting and filter values as tree