### PR TITLE
fix: Handle displaying OR operator in targeting tree

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -8,6 +8,7 @@ export type Variable = z.infer<typeof schemas.Variable>
 export type Variation = z.infer<typeof schemas.Variation>
 export type Feature = z.infer<typeof schemas.Feature>
 export type FeatureConfig = z.infer<typeof schemas.FeatureConfig>
+export type Audience = z.infer<typeof schemas.Audience>
 
 export type CreateEnvironmentParams = z.infer<typeof schemas.CreateEnvironmentDto>
 export const CreateEnvironmentDto = schemas.CreateEnvironmentDto

--- a/src/ui/prompts/listPrompts/filterListPrompt.ts
+++ b/src/ui/prompts/listPrompts/filterListPrompt.ts
@@ -9,7 +9,7 @@ import {
     filterTypePrompt,
     filterValuesPrompt
 } from '../targetingPrompts'
-import { Filter } from '../../../api/schemas'
+import { Audience, Filter } from '../../../api/schemas'
 import { Prompt } from '../types'
 import { chooseFields } from '../../../utils/prompts'
 import { UserSubType } from '../../../api/targeting'
@@ -18,6 +18,8 @@ import { renderDefinitionTree } from '../../targetingTree'
 export class FilterListOptions extends ListOptionsPrompt<Filter> {
     itemType = 'Filter'
     messagePrompt = 'Manage your filters'
+
+    operator: Audience['filters']['operator'] = 'and'
 
     async promptAddItem(): Promise<ListOption<Filter>> {
         const { type } = await inquirer.prompt([filterTypePrompt])
@@ -172,7 +174,7 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
         const listToPrint = list || this.list
         this.writer.statusMessage(`Current ${this.itemType}s:`)
         const values = listToPrint.map((item) => item.value.item)
-        renderDefinitionTree(values)
+        renderDefinitionTree(values, this.operator)
         this.writer.divider()
     }
 }

--- a/src/ui/prompts/listPrompts/targetingListPrompt.ts
+++ b/src/ui/prompts/listPrompts/targetingListPrompt.ts
@@ -48,10 +48,13 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
             projectKey: this.projectKey,
             featureKey: this.featureKey
         })
-        const filters: Filters = await (new FilterListOptions([], this.writer)).prompt()
+        const operator = 'and'
+        const filterListOptions = new FilterListOptions([], this.writer)
+        filterListOptions.operator = operator
+        const filters = await filterListOptions.prompt()
         const target = {
             distribution: [{ _variation: serve.key, percentage: 1 }],
-            audience: { name, filters: { filters, operator: 'and' } }
+            audience: { name, filters: { filters, operator } }
         }
 
         return {
@@ -92,8 +95,9 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
             projectKey: this.projectKey,
             featureKey: this.featureKey
         })
-        const filters: Filters =
-            await (new FilterListOptions(targetToEdit.audience.filters.filters, this.writer)).prompt()
+        const filterListOptions = new FilterListOptions(targetToEdit.audience.filters.filters, this.writer)
+        filterListOptions.operator = targetToEdit.audience.filters.operator
+        const filters = await filterListOptions.prompt()
         const target = {
             distribution: [{ _variation: serve.key, percentage: 1 }],
             audience: { name, filters: { filters, operator: 'and' } }


### PR DESCRIPTION
Currently the tree would always use "AND". Updated to display the prefix based on the operator