### PR TITLE
Dvc 8076 refactor feature prompt

### DIFF
--- a/src/commands/features/delete.ts
+++ b/src/commands/features/delete.ts
@@ -2,7 +2,7 @@ import { Args } from '@oclif/core'
 import { deleteFeature } from '../../api/features'
 import Base from '../base'
 import inquirer from 'inquirer'
-import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
+import { featurePrompt, FeaturePromptResult } from '../../ui/prompts'
 
 export default class DeleteFeatures extends Base {
     static hidden = false

--- a/src/commands/features/delete.ts
+++ b/src/commands/features/delete.ts
@@ -22,11 +22,11 @@ export default class DeleteFeatures extends Base {
 
         let featureKey
         if (!args.feature) {
-            const { feature  } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })
-            featureKey = feature
+            featureKey = feature.key
         } else {
             featureKey = args.feature
         }

--- a/src/commands/features/delete.ts
+++ b/src/commands/features/delete.ts
@@ -2,7 +2,7 @@ import { Args } from '@oclif/core'
 import { deleteFeature } from '../../api/features'
 import Base from '../base'
 import inquirer from 'inquirer'
-import { featurePrompt } from '../../ui/prompts'
+import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
 
 export default class DeleteFeatures extends Base {
     static hidden = false
@@ -22,7 +22,7 @@ export default class DeleteFeatures extends Base {
 
         let featureKey
         if (!args.feature) {
-            const { feature } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })

--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -61,8 +61,8 @@ describe('features update', () => {
     // headless mode:
     dvcTest()
         .nock(BASE_URL, (api) => api
-            .get(`/v1/projects/${projectKey}/features`)
-            .reply(200, [mockFeature])
+            .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+            .reply(200, mockFeature)
         )
         .nock(BASE_URL, (api) => api
             .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBodyWithVariables)
@@ -85,7 +85,7 @@ describe('features update', () => {
                 expect(ctx.stdout).toMatchSnapshot()
             }
         )
-    
+
     dvcTest()
         .stdout()
         .command([
@@ -108,14 +108,14 @@ describe('features update', () => {
     // interactive mode:
     dvcTest()
         .stub(inquirer, 'prompt', () => ({
-            ...requestBody, 
+            ...requestBody,
             sdkVisibility: ['mobile', 'server'],
             whichFields: Object.keys(requestBody),
             listPromptOption: 'continue',
         }))
         .nock(BASE_URL, (api) => api
-            .get(`/v1/projects/${projectKey}/features`)
-            .reply(200, [mockFeature])
+            .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+            .reply(200, mockFeature)
         )
         .nock(BASE_URL, (api) => api
             .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBody)
@@ -142,8 +142,8 @@ describe('features update', () => {
             listPromptOption: 'continue',
         }))
         .nock(BASE_URL, (api) => api
-            .get(`/v1/projects/${projectKey}/features`)
-            .reply(200, [mockFeature])
+            .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+            .reply(200, mockFeature)
         )
         .nock(BASE_URL, (api) => api
             .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBody)

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -1,4 +1,4 @@
-import { fetchFeatures, updateFeature } from '../../api/features'
+import { fetchFeatureByKey, updateFeature } from '../../api/features'
 import {
     descriptionPrompt,
     featurePrompt,
@@ -43,7 +43,8 @@ export default class UpdateFeature extends UpdateCommand {
         const { headless, key, name, description, variables, variations, sdkVisibility } = flags
         await this.requireProject()
 
-        let featureKey = args.key
+        const featureKey = args.key
+        let feature
         if (headless && !featureKey) {
             this.writer.showError('The key argument is required')
             return
@@ -52,14 +53,13 @@ export default class UpdateFeature extends UpdateCommand {
                 token: this.authToken,
                 projectKey: this.projectKey
             })
-            featureKey = response.feature
-        }
-        const features = await fetchFeatures(this.authToken, this.projectKey)
-        const feature = features.find((f) => f._id === featureKey || f.key === featureKey)
-
-        if (!feature) {
-            this.writer.showError(`Feature with key ${featureKey} could not be found`)
-            return
+            feature = response.feature
+        } else {
+            feature = await fetchFeatureByKey(this.authToken, this.projectKey, featureKey)
+            if (!feature) {
+                this.writer.showError(`Feature with key ${featureKey} could not be found`)
+                return
+            }
         }
 
         this.writer.printCurrentValues(feature)

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -1,7 +1,7 @@
 import { fetchFeatureByKey, updateFeature } from '../../api/features'
 import {
     descriptionPrompt,
-    featurePrompt,
+    featurePrompt, FeaturePromptResult,
     getSdkVisibilityPrompt,
     keyPrompt,
     namePrompt,
@@ -49,7 +49,7 @@ export default class UpdateFeature extends UpdateCommand {
             this.writer.showError('The key argument is required')
             return
         } else if (!featureKey) {
-            const response = await inquirer.prompt([featurePrompt], {
+            const response = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })

--- a/src/commands/targeting/disable.ts
+++ b/src/commands/targeting/disable.ts
@@ -1,8 +1,7 @@
 import { Args } from '@oclif/core'
 import { disableTargeting } from '../../api/targeting'
+import { Variation } from '../../api/schemas'
 import Base from '../base'
-import { fetchEnvironmentByKey, fetchEnvironments } from '../../api/environments'
-import { fetchVariations } from '../../api/variations'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
 
@@ -25,7 +24,12 @@ export default class DisableTargeting extends Base {
 
         await this.requireProject()
 
-        const responses = await getFeatureAndEnvironmentKeyFromArgs(
+        const {
+            feature,
+            environment,
+            environmentKey,
+            featureKey
+        } = await getFeatureAndEnvironmentKeyFromArgs(
             this.authToken,
             this.projectKey,
             args,
@@ -34,8 +38,8 @@ export default class DisableTargeting extends Base {
         const updatedTargeting = await disableTargeting(
             this.authToken,
             this.projectKey,
-            responses.featureKey,
-            responses.environmentKey
+            featureKey,
+            environmentKey
         )
 
         if (flags.headless) {
@@ -43,8 +47,8 @@ export default class DisableTargeting extends Base {
         } else {
             renderTargetingTree(
                 [updatedTargeting],
-                [responses.environment],
-                responses.feature.variations
+                [environment],
+                feature.variations as Variation[]
             )
         }
     }

--- a/src/commands/targeting/disable.ts
+++ b/src/commands/targeting/disable.ts
@@ -26,29 +26,26 @@ export default class DisableTargeting extends Base {
         await this.requireProject()
 
         const responses = await getFeatureAndEnvironmentKeyFromArgs(
-            this.authToken, 
-            this.projectKey, 
-            args, 
+            this.authToken,
+            this.projectKey,
+            args,
             flags,
         )
         const updatedTargeting = await disableTargeting(
             this.authToken,
             this.projectKey,
-            responses.featureKey as string,
-            responses.environmentKey as string
-        ) 
-    
+            responses.featureKey,
+            responses.environmentKey
+        )
+
         if (flags.headless) {
             this.writer.showResults(updatedTargeting)
         } else {
-            // TODO: reuse the data fetched for the prompts
-            const environment = await fetchEnvironmentByKey(
-                this.authToken, 
-                this.projectKey, 
-                responses.environmentKey as string
+            renderTargetingTree(
+                [updatedTargeting],
+                [responses.environment],
+                responses.feature.variations
             )
-            const variations = await fetchVariations(this.authToken, this.projectKey, responses.featureKey as string)
-            renderTargetingTree([updatedTargeting], [environment], variations)
         }
     }
 }

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -2,9 +2,7 @@ import { Args } from '@oclif/core'
 import { enableTargeting } from '../../api/targeting'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
-import { fetchVariations } from '../../api/variations'
 import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
-import { fetchEnvironmentByKey } from '../../api/environments'
 
 export default class EnableTargeting extends Base {
     static hidden = false

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -1,5 +1,6 @@
 import { Args } from '@oclif/core'
 import { enableTargeting } from '../../api/targeting'
+import { Variation } from '../../api/schemas'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
 import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
@@ -23,7 +24,12 @@ export default class EnableTargeting extends Base {
 
         await this.requireProject()
 
-        const responses = await getFeatureAndEnvironmentKeyFromArgs(
+        const {
+            feature,
+            environment,
+            environmentKey,
+            featureKey
+        } = await getFeatureAndEnvironmentKeyFromArgs(
             this.authToken,
             this.projectKey,
             args,
@@ -32,8 +38,8 @@ export default class EnableTargeting extends Base {
         const updatedTargeting = await enableTargeting(
             this.authToken,
             this.projectKey,
-            responses.featureKey,
-            responses.environmentKey
+            featureKey,
+            environmentKey
         )
 
         if (flags.headless) {
@@ -41,8 +47,8 @@ export default class EnableTargeting extends Base {
         } else {
             renderTargetingTree(
                 [updatedTargeting],
-                [responses.environment],
-                responses.feature.variations
+                [environment],
+                feature.variations as Variation[]
             )
         }
     }

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -26,29 +26,26 @@ export default class EnableTargeting extends Base {
         await this.requireProject()
 
         const responses = await getFeatureAndEnvironmentKeyFromArgs(
-            this.authToken, 
-            this.projectKey, 
-            args, 
+            this.authToken,
+            this.projectKey,
+            args,
             flags,
         )
         const updatedTargeting = await enableTargeting(
             this.authToken,
             this.projectKey,
-            responses.featureKey as string,
-            responses.environmentKey as string
-        ) 
-    
+            responses.featureKey,
+            responses.environmentKey
+        )
+
         if (flags.headless) {
             this.writer.showResults(updatedTargeting)
         } else {
-            // TODO: reuse the data fetched for the prompts
-            const environment = await fetchEnvironmentByKey(
-                this.authToken, 
-                this.projectKey, 
-                responses.environmentKey as string
+            renderTargetingTree(
+                [updatedTargeting],
+                [responses.environment],
+                responses.feature.variations
             )
-            const variations = await fetchVariations(this.authToken, this.projectKey, responses.featureKey as string)
-            renderTargetingTree([updatedTargeting], [environment], variations)
         }
     }
 }

--- a/src/commands/targeting/get.test.ts
+++ b/src/commands/targeting/get.test.ts
@@ -167,7 +167,7 @@ describe('targeting get', () => {
             .reply(200, mockEnvironments)
         )
         .stub(inquirer, 'prompt', () => {
-            return { feature: 'prompted-feature-id' }
+            return { feature:  { key: 'prompted-feature-id' } }
         })
         .stdout()
         .command(['targeting get', ...authFlags])
@@ -176,7 +176,7 @@ describe('targeting get', () => {
                 expect(ctx.stdout).toMatchSnapshot()
             })
 
-    dvcTest() 
+    dvcTest()
         .stdout()
         .command(['targeting get', '--headless', ...authFlags])
         .it('does not prompt when using --headless',

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -39,7 +39,8 @@ export default class DetailedTargeting extends Base {
         await this.requireProject()
 
         const params: Params = {
-            featureKey: args.feature
+            featureKey: args.feature,
+            environment_id: args.environment
         }
 
         // TODO: this should use populateParameters once it's added to Base class
@@ -58,7 +59,7 @@ export default class DetailedTargeting extends Base {
             Object.assign(params, {
                 feature: responses.feature,
                 featureKey: responses.feature.key,
-                environment_id: responses.environment?._id,
+                environment_id: responses.environment?.key,
                 environment: responses.environment
             })
         }
@@ -78,7 +79,6 @@ export default class DetailedTargeting extends Base {
         if (flags.headless) {
             this.writer.showResults(targeting)
         } else {
-            // TODO: reuse the data fetched for the prompts
             const environments = params.environment ?
                 [params.environment] : await fetchEnvironments(this.authToken, this.projectKey)
             const variations = params.feature?.variations

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -6,7 +6,14 @@ import { fetchTargetingForFeature } from '../../api/targeting'
 import { environmentPrompt, EnvironmentPromptResult, featurePrompt, FeaturePromptResult } from '../../ui/prompts'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
+import { Feature, Environment } from '../../api/schemas'
 
+type Params = {
+    featureKey?: string,
+    environment_id?: string,
+    feature?: Feature,
+    environment?: Environment
+}
 export default class DetailedTargeting extends Base {
     static hidden = false
     static description = 'Retrieve Targeting for a Feature from the Management API'
@@ -31,10 +38,12 @@ export default class DetailedTargeting extends Base {
 
         await this.requireProject()
 
-        const params = Object.assign({}, args)
+        const params: Params = {
+            featureKey: args.feature
+        }
 
         // TODO: this should use populateParameters once it's added to Base class
-        if (!flags.headless && !params.feature) {
+        if (!flags.headless && !params.featureKey) {
             Object.keys(args).forEach((key) => {
                 this.prompts = this.prompts.filter((prompt) => prompt.name !== key)
             })
@@ -48,11 +57,13 @@ export default class DetailedTargeting extends Base {
             )
             Object.assign(params, {
                 feature: responses.feature,
-                environment: responses.environment?._id
+                featureKey: responses.feature.key,
+                environment_id: responses.environment?._id,
+                environment: responses.environment
             })
         }
 
-        if (!params.feature) {
+        if (!params.featureKey) {
             this.writer.showError('Feature argument is required')
             return
         }
@@ -60,16 +71,18 @@ export default class DetailedTargeting extends Base {
         const targeting = await fetchTargetingForFeature(
             this.authToken,
             this.projectKey,
-            params.feature,
-            params.environment
+            params.featureKey,
+            params.environment_id
         )
 
         if (flags.headless) {
             this.writer.showResults(targeting)
         } else {
             // TODO: reuse the data fetched for the prompts
-            const environments = await fetchEnvironments(this.authToken, this.projectKey)
-            const variations = await fetchVariations(this.authToken, this.projectKey, params.feature)
+            const environments = params.environment ?
+                [params.environment] : await fetchEnvironments(this.authToken, this.projectKey)
+            const variations = params.feature?.variations
+                || await fetchVariations(this.authToken, this.projectKey, params.featureKey)
             renderTargetingTree(targeting, environments, variations)
         }
     }

--- a/src/commands/targeting/update.ts
+++ b/src/commands/targeting/update.ts
@@ -56,7 +56,7 @@ export default class UpdateTargeting extends Base {
                     projectKey: this.projectKey
                 }
             )
-            featureKey = promptResult.feature
+            featureKey = promptResult.feature.key
         }
 
         let envKey = args.environment

--- a/src/commands/variations/create.test.ts
+++ b/src/commands/variations/create.test.ts
@@ -151,8 +151,12 @@ describe('variations create', () => {
 
     dvcTest()
         .nock(BASE_URL, (api) => api
-            .get(`/v1/projects/${projectKey}/variables?feature=${featureKey}`)
+            .get(`/v1/projects/${projectKey}/variables?feature=${mockFeature._id}`)
             .reply(200, mockVariables)
+        )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/features/${featureKey}`)
+            .reply(200, mockFeature)
         )
         .nock(BASE_URL, (api) => api
             .post(`/v1/projects/${projectKey}/features/${featureKey}/variations`, requestBody)

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer'
 import { Args, Flags } from '@oclif/core'
 import {
-    featurePrompt,
+    featurePrompt, FeaturePromptResult,
     keyPrompt,
     namePrompt
 } from '../../ui/prompts'
@@ -46,7 +46,7 @@ export default class CreateVariation extends CreateCommand {
         let featureKey
         let feature_id
         if (!args.feature) {
-            const { feature } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -10,7 +10,7 @@ import { CreateVariationDto } from '../../api/schemas'
 import { createVariation } from '../../api/variations'
 import { promptForVariationVariableValues } from '../../ui/prompts/variationPrompts'
 import { fetchVariables } from '../../api/variables'
-import {fetchFeatureByKey} from "../../api/features";
+import { fetchFeatureByKey } from '../../api/features'
 
 export default class CreateVariation extends CreateCommand {
     static hidden = false

--- a/src/commands/variations/get.ts
+++ b/src/commands/variations/get.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { fetchVariations } from '../../api/variations'
-import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
+import { featurePrompt, FeaturePromptResult } from '../../ui/prompts'
 import Base from '../base'
 import { Args } from '@oclif/core'
 
@@ -30,7 +30,7 @@ export default class GetVariations extends Base {
                 projectKey: this.projectKey
             })
 
-            featureKey = feature
+            featureKey = feature.key
         } else {
             featureKey = args.feature
         }

--- a/src/commands/variations/get.ts
+++ b/src/commands/variations/get.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { fetchVariations } from '../../api/variations'
-import { featurePrompt } from '../../ui/prompts'
+import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
 import Base from '../base'
 import { Args } from '@oclif/core'
 
@@ -25,7 +25,7 @@ export default class GetVariations extends Base {
             this.writer.showError('In headless mode, feature is required')
             return
         } else if (!args.feature) {
-            const { feature } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })

--- a/src/commands/variations/list.test.ts
+++ b/src/commands/variations/list.test.ts
@@ -47,7 +47,7 @@ describe('variations list', () => {
             .reply(200, mockVariations)
         )
         .stub(inquirer, 'prompt', () => {
-            return { feature: 'prompted-feature-id' }
+            return { feature: { key: 'prompted-feature-id' } }
         })
         .stdout()
         .command(['variations list', '--project', projectKey, ...authFlags])

--- a/src/commands/variations/list.ts
+++ b/src/commands/variations/list.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { fetchVariations } from '../../api/variations'
-import { featurePrompt } from '../../ui/prompts'
+import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
 import Base from '../base'
 import { Args } from '@oclif/core'
 
@@ -25,12 +25,12 @@ export default class ListVariations extends Base {
             this.writer.showError('In headless mode, feature is required')
             return
         } else if (!args.feature) {
-            const { feature } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })
 
-            featureKey = feature
+            featureKey = feature.key
         } else {
             featureKey = args.feature
         }

--- a/src/commands/variations/list.ts
+++ b/src/commands/variations/list.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { fetchVariations } from '../../api/variations'
-import {featurePrompt, FeaturePromptResult} from '../../ui/prompts'
+import { featurePrompt, FeaturePromptResult } from '../../ui/prompts'
 import Base from '../base'
 import { Args } from '@oclif/core'
 

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer'
 import UpdateCommand from '../updateCommand'
 import { fetchVariationByKey, updateVariation, UpdateVariationParams } from '../../api/variations'
-import { featurePrompt, keyPrompt, namePrompt } from '../../ui/prompts'
+import {featurePrompt, FeaturePromptResult, keyPrompt, namePrompt} from '../../ui/prompts'
 import { Feature, Variable } from '../../api/schemas'
 
 import {
@@ -50,11 +50,11 @@ export default class UpdateVariation extends UpdateCommand {
         const { variables, name, key, headless } = flags
         let featureKey
         if (!args.feature) {
-            const { feature } = await inquirer.prompt([featurePrompt], {
+            const { feature } = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
                 token: this.authToken,
                 projectKey: this.projectKey
             })
-            featureKey = feature
+            featureKey = feature.key
         } else {
             featureKey = args.feature
         }

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer'
 import UpdateCommand from '../updateCommand'
 import { fetchVariationByKey, updateVariation, UpdateVariationParams } from '../../api/variations'
-import {featurePrompt, FeaturePromptResult, keyPrompt, namePrompt} from '../../ui/prompts'
+import { featurePrompt, FeaturePromptResult, keyPrompt, namePrompt } from '../../ui/prompts'
 import { Feature, Variable } from '../../api/schemas'
 
 import {

--- a/src/ui/prompts/featurePrompts.ts
+++ b/src/ui/prompts/featurePrompts.ts
@@ -5,7 +5,7 @@ import { autocompleteSearch } from '../autocomplete'
 
 type FeatureChoice = {
     name: string,
-    value: string
+    value: Feature
 }
 
 export type FeaturePromptResult = {
@@ -20,10 +20,10 @@ export const featureChoices = async (input: Record<string, any>, search: string)
         choices = features.map((feature: Feature) => {
             return {
                 name: feature.name || feature.key,
-                value: feature.key
+                value: feature
             }
         })
-    
+
     }
 
     return autocompleteSearch(choices, search)
@@ -38,6 +38,7 @@ export const featurePrompt = {
 
 export const variableFeaturePrompt = {
     ...featurePrompt,
+    transformResponse: (response: Feature) => response.key,
     name: '_feature',
 }
 
@@ -58,7 +59,7 @@ export const getSDKVisibilityChoices = (sdkVisibility?: Feature['sdkVisibility']
             name: 'client',
             value: 'client',
             checked: typeof sdkVisibility?.client !== 'undefined' ? sdkVisibility?.client : false
-        }, 
+        },
         {
             name: 'server',
             value: 'server',
@@ -76,7 +77,7 @@ export const getSdkVisibilityPrompt = (feature?: Feature) => {
         transformResponse: (response: string[]) => ({
             mobile: response.includes('mobile'),
             client: response.includes('client'),
-            server: response.includes('server')    
+            server: response.includes('server')
         })
     }
 }

--- a/src/utils/targeting/index.ts
+++ b/src/utils/targeting/index.ts
@@ -1,6 +1,6 @@
 import { disableTargeting, enableTargeting } from '../../api/targeting'
 import inquirer from '../../ui/autocomplete'
-import { featurePrompt, EnvironmentPromptResult, environmentPrompt } from '../../ui/prompts'
+import {featurePrompt, EnvironmentPromptResult, environmentPrompt, FeaturePromptResult} from '../../ui/prompts'
 import { fetchFeatureByKey } from '../../api/features'
 import { Feature, Environment } from '../../api/schemas'
 import { fetchEnvironmentByKey } from '../../api/environments'
@@ -20,7 +20,7 @@ export const getFeatureAndEnvironmentKeyFromArgs = async (
     }
 
     if (!featureKey) {
-        const userSelectedFeature = await inquirer.prompt(
+        const userSelectedFeature = await inquirer.prompt<FeaturePromptResult>(
             [featurePrompt],
             {
                 token: authToken,

--- a/src/utils/targeting/index.ts
+++ b/src/utils/targeting/index.ts
@@ -1,16 +1,21 @@
-import { disableTargeting, enableTargeting } from '../../api/targeting'
 import inquirer from '../../ui/autocomplete'
-import {featurePrompt, EnvironmentPromptResult, environmentPrompt, FeaturePromptResult} from '../../ui/prompts'
+import { featurePrompt, EnvironmentPromptResult, environmentPrompt, FeaturePromptResult } from '../../ui/prompts'
 import { fetchFeatureByKey } from '../../api/features'
 import { Feature, Environment } from '../../api/schemas'
 import { fetchEnvironmentByKey } from '../../api/environments'
 
+type Response = {
+    environmentKey: string
+    featureKey: string
+    environment: Environment,
+    feature: Feature
+}
 export const getFeatureAndEnvironmentKeyFromArgs = async (
     authToken: string,
     projectKey: string,
     args: Record<string, string | undefined>,
     flags: Record<string, string | undefined>
-) => {
+): Promise<Response> => {
     const featureKey = args['feature']
     const environmentKey = args['environment']
     let feature, environment


### PR DESCRIPTION
- Change FeaturePrompt to return the full feature object rather than just the key
- VariableFeaturePrompt still just returns the key, uses a transformer on the feature prompt answer to do so
- Update everywhere that uses FeaturePrompt to support the new output
- Remove a bunch of redundant API calls to fetch the feature
- Fix a bug with variations create where it would send the featureKey as a query param to variables GET
- Update all affected unit tests to mock out the correct api calls