### PR TITLE
chore: output targeting enable disable as a tree

### DIFF
--- a/src/api/environments.ts
+++ b/src/api/environments.ts
@@ -48,22 +48,13 @@ export const fetchEnvironmentByKey = async (
     project_id: string,
     key: string
 ) => {
-    try {
-        const response = await apiClient.get('/v1/projects/:project/environments/:key', {
-            headers: buildHeaders(token),
-            params: {
-                project: project_id,
-                key
-            }
-        })
-
-        return response
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-        if (e.response?.status === 404) {
-            return null
+    const response = await apiClient.get('/v1/projects/:project/environments/:key', {
+        headers: buildHeaders(token),
+        params: {
+            project: project_id,
+            key
         }
-        throw e
-    }
+    })
 
+    return response
 }

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -1,8 +1,10 @@
 import { Args } from '@oclif/core'
-import inquirer from '../../ui/autocomplete'
 import { enableTargeting } from '../../api/targeting'
-import { EnvironmentPromptResult, environmentPrompt, featurePrompt } from '../../ui/prompts'
+import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
+import { fetchVariations } from '../../api/variations'
+import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
+import { fetchEnvironmentByKey } from '../../api/environments'
 
 export default class EnableTargeting extends Base {
     static hidden = false
@@ -23,47 +25,30 @@ export default class EnableTargeting extends Base {
 
         await this.requireProject()
 
-        let responses
-
-        const feature = args['feature']
-        const environment = args['environment']
-
-        if (flags.headless && (!feature || !environment)) {
-            throw new Error('In headless mode, both the feature and environment are required')
-        }
-
-        if (feature) {
-            responses = { featureKey: feature }
-        } else {
-            const userSelectedFeature = await inquirer.prompt(
-                [featurePrompt],
-                {
-                    token: this.authToken,
-                    projectKey: this.projectKey
-                }
-            )
-            responses = { featureKey: userSelectedFeature.feature }
-        }
-
-        if (environment) {
-            responses = { ...responses, environmentKey: environment }
-        } else {
-            const userSelectedEnv = await inquirer.prompt<EnvironmentPromptResult>(
-                [environmentPrompt],
-                {
-                    token: this.authToken,
-                    projectKey: this.projectKey
-                }
-            )
-            responses = { ...responses, environmentKey: userSelectedEnv.environment._id }
-        }
-
-        const enableTargetingForFeatureAndEnvironment = await enableTargeting(
+        const responses = await getFeatureAndEnvironmentKeyFromArgs(
+            this.authToken, 
+            this.projectKey, 
+            args, 
+            flags,
+        )
+        const updatedTargeting = await enableTargeting(
             this.authToken,
             this.projectKey,
-            responses.featureKey,
-            responses.environmentKey
-        )
-        return this.writer.showResults(enableTargetingForFeatureAndEnvironment)
+            responses.featureKey as string,
+            responses.environmentKey as string
+        ) 
+    
+        if (flags.headless) {
+            this.writer.showResults(updatedTargeting)
+        } else {
+            // TODO: reuse the data fetched for the prompts
+            const environment = await fetchEnvironmentByKey(
+                this.authToken, 
+                this.projectKey, 
+                responses.environmentKey as string
+            )
+            const variations = await fetchVariations(this.authToken, this.projectKey, responses.featureKey as string)
+            renderTargetingTree([updatedTargeting], [environment], variations)
+        }
     }
 }

--- a/src/ui/prompts/environmentPrompts.ts
+++ b/src/ui/prompts/environmentPrompts.ts
@@ -6,6 +6,7 @@ import { PromptResult } from '.'
 import { CreateEnvironmentDto, Environment } from '../../api/schemas'
 
 import { autocompleteSearch } from '../autocomplete'
+
 type EnvironmentChoice = {
     name: string,
     value: Environment

--- a/src/utils/targeting/index.ts
+++ b/src/utils/targeting/index.ts
@@ -1,0 +1,46 @@
+import { disableTargeting, enableTargeting } from '../../api/targeting'
+import inquirer from '../../ui/autocomplete'
+import { featurePrompt, EnvironmentPromptResult, environmentPrompt } from '../../ui/prompts'
+
+export const getFeatureAndEnvironmentKeyFromArgs = async (
+    authToken: string, 
+    projectKey: string,
+    args: Record<string, string | undefined>,
+    flags: Record<string, string | undefined>
+) => {
+    const featureKey = args['feature']
+    const environmentKey = args['environment']
+
+    const responses = {
+        featureKey: featureKey,
+        environmentKey: environmentKey
+    }
+
+    if (flags.headless && (!featureKey || !environmentKey)) {
+        throw new Error('In headless mode, both the feature and environment are required')
+    }
+
+    if (!featureKey) {
+        const userSelectedFeature = await inquirer.prompt(
+            [featurePrompt],
+            {
+                token: authToken,
+                projectKey: projectKey
+            }
+        )
+        responses.featureKey = userSelectedFeature.feature
+    }
+
+    if (!environmentKey) {
+        const userSelectedEnv = await inquirer.prompt<EnvironmentPromptResult>(
+            [environmentPrompt],
+            {
+                token: authToken,
+                projectKey: projectKey
+            }
+        )
+        responses.environmentKey = userSelectedEnv.environment._id
+    }
+
+    return responses
+}


### PR DESCRIPTION
# Changes

- Refactor enable / disable targeting commands to use common method
- output response of enable / disable targeting as a tree