### PR TITLE
chore: handle outputting in targeting tree audience match filters

### DIFF
--- a/src/api/audiences.ts
+++ b/src/api/audiences.ts
@@ -1,0 +1,16 @@
+import apiClient from './apiClient'
+import { buildHeaders } from './common'
+
+const BASE_URL = '/v1/projects/:project/audiences'
+
+export const fetchAudiences = async (
+    token: string,
+    project_id: string
+) => {
+    return apiClient.get(`${BASE_URL}`, {
+        headers: buildHeaders(token),
+        params: {
+            project: project_id,
+        }
+    })
+}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -9,6 +9,7 @@ export type Variation = z.infer<typeof schemas.Variation>
 export type Feature = z.infer<typeof schemas.Feature>
 export type FeatureConfig = z.infer<typeof schemas.FeatureConfig>
 export type Audience = z.infer<typeof schemas.Audience>
+export type Target = z.infer<typeof schemas.Target>
 
 export type CreateEnvironmentParams = z.infer<typeof schemas.CreateEnvironmentDto>
 export const CreateEnvironmentDto = schemas.CreateEnvironmentDto
@@ -42,26 +43,26 @@ export const UpdateTargetDto = schemas.UpdateTargetDto
 export type AudienceOperatorWithAudienceMatchFilter = z.infer<typeof schemas.AudienceOperatorWithAudienceMatchFilter>
 export type Filters = z.infer<typeof schemas.AudienceOperatorWithAudienceMatchFilter.shape.filters>
 
-type AllFilter = z.infer<typeof schemas.AllFilter>
-export const AllFilter = schemas.AllFilter
+export type AllFilter = z.infer<typeof schemas.AllFilter>
+export const AllFilterSchema = schemas.AllFilter
 
-type UserFilter = z.infer<typeof schemas.UserFilter>
-export const UserFilter = schemas.UserFilter
+export type UserFilter = z.infer<typeof schemas.UserFilter>
+export const UserFilterSchema = schemas.UserFilter
 
-type UserCountryFilter = z.infer<typeof schemas.UserCountryFilter>
-export const UserCountryFilter = schemas.UserCountryFilter
+export type UserCountryFilter = z.infer<typeof schemas.UserCountryFilter>
+export const UserCountryFilterSchema = schemas.UserCountryFilter
 
-type UserAppVersionFilter = z.infer<typeof schemas.UserAppVersionFilter>
-export const UserAppVersionFilter = schemas.UserAppVersionFilter
+export type UserAppVersionFilter = z.infer<typeof schemas.UserAppVersionFilter>
+export const UserAppVersionFilterSchema = schemas.UserAppVersionFilter
 
-type UserPlatformVersionFilter = z.infer<typeof schemas.UserPlatformVersionFilter>
-export const UserPlatformVersionFilter = schemas.UserPlatformVersionFilter
+export type UserPlatformVersionFilter = z.infer<typeof schemas.UserPlatformVersionFilter>
+export const UserPlatformVersionFilterSchema = schemas.UserPlatformVersionFilter
 
-type UserCustomFilter = z.infer<typeof schemas.UserCustomFilter>
-export const UserCustomFilter = schemas.UserCustomFilter
+export type UserCustomFilter = z.infer<typeof schemas.UserCustomFilter>
+export const UserCustomFilterSchema = schemas.UserCustomFilter
 
-type AudienceMatchFilter = z.infer<typeof schemas.AudienceMatchFilter>
-export const AudienceMatchFilter = schemas.AudienceMatchFilter
+export type AudienceMatchFilter = z.infer<typeof schemas.AudienceMatchFilter>
+export const AudienceMatchFilterSchema = schemas.AudienceMatchFilter
 
 export type Filter = 
   | AllFilter

--- a/src/commands/targeting/disable.ts
+++ b/src/commands/targeting/disable.ts
@@ -4,6 +4,7 @@ import { Variation } from '../../api/schemas'
 import Base from '../base'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
+import { fetchAudiences } from '../../api/audiences'
 
 export default class DisableTargeting extends Base {
     static hidden = false
@@ -45,10 +46,12 @@ export default class DisableTargeting extends Base {
         if (flags.headless) {
             this.writer.showResults(updatedTargeting)
         } else {
+            const audiences = await fetchAudiences(this.authToken, this.projectKey)
             renderTargetingTree(
-                [updatedTargeting],
+                [updatedTargeting], 
                 [environment],
-                feature.variations as Variation[]
+                feature.variations as Variation[],
+                audiences
             )
         }
     }

--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -4,6 +4,7 @@ import { Variation } from '../../api/schemas'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
 import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
+import { fetchAudiences } from '../../api/audiences'
 
 export default class EnableTargeting extends Base {
     static hidden = false
@@ -45,10 +46,12 @@ export default class EnableTargeting extends Base {
         if (flags.headless) {
             this.writer.showResults(updatedTargeting)
         } else {
+            const audiences = await fetchAudiences(this.authToken, this.projectKey)
             renderTargetingTree(
-                [updatedTargeting],
+                [updatedTargeting], 
                 [environment],
-                feature.variations as Variation[]
+                feature.variations as Variation[],
+                audiences
             )
         }
     }

--- a/src/commands/targeting/get.test.ts
+++ b/src/commands/targeting/get.test.ts
@@ -127,6 +127,10 @@ describe('targeting get', () => {
             .get(`/v1/projects/${projectKey}/environments`)
             .reply(200, mockEnvironments)
         )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/audiences`)
+            .reply(200, [])
+        )
         .stdout()
         .command(['targeting get', featureKey, ...authFlags])
         .it('returns all targeting for a feature', (ctx) => {
@@ -145,6 +149,10 @@ describe('targeting get', () => {
         .nock(BASE_URL, (api) => api
             .get(`/v1/projects/${projectKey}/environments`)
             .reply(200, mockEnvironments)
+        )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/audiences`)
+            .reply(200, [])
         )
         .stdout()
         .command(['targeting get', featureKey, 'development', ...authFlags])
@@ -165,6 +173,10 @@ describe('targeting get', () => {
         .nock(BASE_URL, (api) => api
             .get(`/v1/projects/${projectKey}/environments`)
             .reply(200, mockEnvironments)
+        )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/audiences`)
+            .reply(200, [])
         )
         .stub(inquirer, 'prompt', () => {
             return { feature:  { key: 'prompted-feature-id' } }

--- a/src/commands/targeting/get.ts
+++ b/src/commands/targeting/get.ts
@@ -3,10 +3,16 @@ import inquirer from '../../ui/autocomplete'
 import { fetchEnvironments } from '../../api/environments'
 import { fetchVariations } from '../../api/variations'
 import { fetchTargetingForFeature } from '../../api/targeting'
-import { environmentPrompt, EnvironmentPromptResult, featurePrompt, FeaturePromptResult } from '../../ui/prompts'
+import { 
+    environmentPrompt, 
+    EnvironmentPromptResult, 
+    featurePrompt, 
+    FeaturePromptResult 
+} from '../../ui/prompts'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
 import { Feature, Environment } from '../../api/schemas'
+import { fetchAudiences } from '../../api/audiences'
 
 type Params = {
     featureKey?: string,
@@ -83,7 +89,13 @@ export default class DetailedTargeting extends Base {
                 [params.environment] : await fetchEnvironments(this.authToken, this.projectKey)
             const variations = params.feature?.variations
                 || await fetchVariations(this.authToken, this.projectKey, params.featureKey)
-            renderTargetingTree(targeting, environments, variations)
+            const audiences = await fetchAudiences(this.authToken, this.projectKey)
+            renderTargetingTree(
+                targeting, 
+                environments, 
+                variations,
+                audiences
+            )
         }
     }
 }

--- a/src/commands/targeting/update.test.ts
+++ b/src/commands/targeting/update.test.ts
@@ -203,6 +203,10 @@ describe('targeting update', () => {
             .query({ environment: envKey })
             .reply(200, mockResponseHeadless)
         )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/audiences`)
+            .reply(200, [])
+        )
         .stdout()
         .command([
             'targeting update',
@@ -274,6 +278,10 @@ describe('targeting update', () => {
             .get(`/v1/projects/${projectKey}/features/${featureKey}/configurations`)
             .query({ environment: envKey })
             .reply(200, mockTargetingRules)
+        )
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/audiences`)
+            .reply(200, [])
         )
         .nock(BASE_URL, (api) => api
             .patch(

--- a/src/commands/targeting/update.ts
+++ b/src/commands/targeting/update.ts
@@ -22,6 +22,7 @@ import { fetchVariations } from '../../api/variations'
 import { FeatureConfig, UpdateFeatureConfigDto } from '../../api/schemas'
 import { targetingStatusPrompt } from '../../ui/prompts/targetingPrompts'
 import UpdateCommand from '../updateCommand'
+import { fetchAudiences } from '../../api/audiences'
 
 export default class UpdateTargeting extends UpdateCommand {
     static hidden = false
@@ -86,6 +87,7 @@ export default class UpdateTargeting extends UpdateCommand {
 
         const environment = await fetchEnvironmentByKey(this.authToken, this.projectKey, envKey)
         const variations = await fetchVariations(this.authToken, this.projectKey, featureKey)
+        const audiences = await fetchAudiences(this.authToken, this.projectKey)
 
         const status = this.convertStatusFlagValue(flags.status)
         let targets: UpdateFeatureConfigDto['targets']
@@ -111,7 +113,12 @@ export default class UpdateTargeting extends UpdateCommand {
                 this.authToken, this.projectKey, featureKey, envKey
             )
             const targetingListPrompt = new TargetingListOptions(
-                featureTargetingRules.targets, this.writer, this.authToken, this.projectKey, featureKey
+                featureTargetingRules.targets, 
+                audiences,
+                this.writer, 
+                this.authToken, 
+                this.projectKey, 
+                featureKey
             )
             targetingListPrompt.variations = variations
             this.prompts.push(targetingListPrompt.getTargetingListPrompt())
@@ -137,7 +144,8 @@ export default class UpdateTargeting extends UpdateCommand {
             renderTargetingTree(
                 [result],
                 environment ? [environment] : [],
-                variations
+                variations,
+                audiences
             )
             this.showSuggestedCommand(featureKey, envKey, result)
         }

--- a/src/ui/prompts/listPrompts/filterListPrompt.ts
+++ b/src/ui/prompts/listPrompts/filterListPrompt.ts
@@ -14,12 +14,20 @@ import { Prompt } from '../types'
 import { chooseFields } from '../../../utils/prompts'
 import { UserSubType } from '../../../api/targeting'
 import { renderDefinitionTree } from '../../targetingTree'
+import { buildAudienceNameMap, replaceAudienceIdInFilter } from '../../../utils/audiences'
+import Writer from '../../writer'
 
 export class FilterListOptions extends ListOptionsPrompt<Filter> {
     itemType = 'Filter'
     messagePrompt = 'Manage your filters'
 
     operator: Audience['filters']['operator'] = 'and'
+    audiences: Audience[]
+    
+    constructor(list: Filter[], audiences: Audience[], writer: Writer) {
+        super(list, writer)
+        this.audiences = audiences
+    }
 
     async promptAddItem(): Promise<ListOption<Filter>> {
         const { type } = await inquirer.prompt([filterTypePrompt])
@@ -170,7 +178,7 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
         return []
     }
 
-    async printListOptions(list?: ListOption<Filter>[]) {
+    printListOptions(list?: ListOption<Filter>[]) {
         const listToPrint = list || this.list
         if (listToPrint.length === 0) {
             this.writer.infoMessage(`No existing ${this.itemType}s.`)
@@ -180,7 +188,7 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
         this.writer.title(this.messagePrompt)
         this.writer.infoMessage(`Current ${this.itemType}s:`)
         const values = listToPrint.map((item) => item.value.item)
-        renderDefinitionTree(values, this.operator)
+        renderDefinitionTree(values, this.operator, this.audiences)
         this.writer.blankLine()
     }
 }

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -164,7 +164,7 @@ export abstract class ListOptionsPrompt<T> {
      * Prints the list of human-readable names of the list to the console
      * @param ListOption<T>[]
      */
-    async printListOptions(list?: ListOption<T>[]) {
+    printListOptions(list?: ListOption<T>[]) {
         const listToPrint = list || this.list
         if (listToPrint.length === 0) {
             this.writer.infoMessage(`No existing ${this.itemType}s.`)

--- a/src/ui/prompts/listPrompts/targetingListPrompt.ts
+++ b/src/ui/prompts/listPrompts/targetingListPrompt.ts
@@ -9,7 +9,7 @@ import {
     ReorderItemPrompt
 } from './promptOptions'
 import { servePrompt } from '../targetingPrompts'
-import { UpdateTargetParams, Variation } from '../../../api/schemas'
+import { Audience, Filters, UpdateTargetParams, Variation } from '../../../api/schemas'
 import { FilterListOptions } from './filterListPrompt'
 import Writer from '../../writer'
 import { renderRulesTree } from '../../targetingTree'
@@ -23,9 +23,18 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
     featureKey: string
 
     variations: Variation[] = []
+    audiences: Audience[]
 
-    constructor(list: UpdateTargetParams[], writer: Writer, authToken: string, projectKey: string, featureKey: string) {
+    constructor(
+        list: UpdateTargetParams[], 
+        audiences: Audience[], 
+        writer: Writer, 
+        authToken: string, 
+        projectKey: string, 
+        featureKey: string
+    ) {
         super(list, writer)
+        this.audiences = audiences
         this.featureKey = featureKey
         this.authToken = authToken
         this.projectKey = projectKey
@@ -57,7 +66,7 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
             featureKey: this.featureKey
         })
         const operator = 'and'
-        const filterListOptions = new FilterListOptions([], this.writer)
+        const filterListOptions = new FilterListOptions([], this.audiences, this.writer)
         filterListOptions.operator = operator
         const filters = await filterListOptions.prompt()
         const target = {
@@ -103,7 +112,11 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
             projectKey: this.projectKey,
             featureKey: this.featureKey
         })
-        const filterListOptions = new FilterListOptions(targetToEdit.audience.filters.filters, this.writer)
+        const filterListOptions = new FilterListOptions(
+            targetToEdit.audience.filters.filters, 
+            this.audiences,
+            this.writer
+        )
         filterListOptions.operator = targetToEdit.audience.filters.operator
         const filters = await filterListOptions.prompt()
         const target = {
@@ -125,7 +138,7 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
         }))
     }
 
-    async printListOptions(list?: ListOption<UpdateTargetParams>[]) {
+    printListOptions(list?: ListOption<UpdateTargetParams>[]) {
         const listToPrint = list || this.list
         if (listToPrint.length === 0) {
             this.writer.infoMessage(`No existing ${this.itemType}s.`)
@@ -135,7 +148,7 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
         this.writer.title(this.messagePrompt)
         this.writer.infoMessage(`Current ${this.itemType}s:`)
         const values = listToPrint.map((item) => item.value.item)
-        renderRulesTree(values, this.variations)
+        renderRulesTree(values, this.variations, this.audiences)
         this.writer.blankLine()
     }
 }

--- a/src/utils/audiences/index.ts
+++ b/src/utils/audiences/index.ts
@@ -1,0 +1,29 @@
+import { fetchAudiences } from '../../api/audiences'
+import { FeatureConfig } from '../../api/schemas'
+
+export const replaceIdsInTargetingWithNames = async (
+    featureConfigs: FeatureConfig[],
+    token: string,
+    project_id: string
+) => {
+    const audiences = await fetchAudiences(token, project_id)
+    return featureConfigs.map((featureConfig) => {
+        const newFeatureConfig = { ...featureConfig }
+        newFeatureConfig.targets.map((target) => {
+            const filters = target.audience.filters.filters.map((filter) => {
+                const newFilter = { ...filter }
+                if (newFilter.type === 'audienceMatch') {
+                    const audienceIds = newFilter._audiences!
+                    const audienceNames = audienceIds.map((audienceId) => {
+                        const audience = audiences.find((audience) => audience._id === audienceId)
+                        return audience?.name || ''
+                    })
+                    newFilter._audiences = audienceNames
+                }
+                return newFilter
+            })
+            target.audience.filters.filters = filters
+        })
+        return newFeatureConfig
+    })
+}

--- a/src/utils/audiences/utils.test.ts
+++ b/src/utils/audiences/utils.test.ts
@@ -1,0 +1,71 @@
+import { expect } from '@oclif/test'
+import { replaceIdsInTargetingWithNames } from '.'
+
+describe.only('Audience Utils Test', () => {
+
+    const audiences = [
+        {
+            _id: '1',
+            name: 'Audience 1'
+        },
+        {
+            _id: '2',
+            name: 'Audience 2'
+        },
+    ]
+    const featureConfigs = [
+        {
+            '_feature': 'feature-id',
+            '_environment': 'environment-id',
+            '_createdBy': 'test',
+            'status': 'active',
+            'startedAt': '2023-07-05T19:43:45.076Z',
+            'updatedAt': '2023-07-05T19:50:06.329Z',
+            'targets': [
+                {
+                    '_id': '64a5c96e710da6dc8604994a',
+                    'name': 'Test Target',
+                    'audience': {
+                        'name': 'Test Audience',
+                        'filters': {
+                            'operator': 'and',
+                            'filters': [
+                                {
+                                    'type': 'audienceMatch',
+                                    '_audiences': [
+                                        '1'
+                                    ],
+                                    'comparator': '='
+                                },
+                                {
+                                    'type': 'user',
+                                    'subType': 'email',
+                                    'values': [
+                                        'new@email.com'
+                                    ],
+                                    'comparator': '='
+                                }
+                            ]
+                        }
+                    },
+                    'distribution': [
+                        {
+                            '_variation': '649f2ed02e588411dce577a9',
+                            'percentage': 1
+                        }
+                    ]
+                }
+            ],
+            'readonly': false
+        }
+    ]
+    it('should replace audience ids with audience names', async () => {
+        const newFeatureConfigs = await replaceIdsInTargetingWithNames(featureConfigs as any, audiences as any)
+        expect(newFeatureConfigs[0].targets[0].audience.filters.filters[0]._audiences).to.deep.equal(['Audience 1'])
+    })
+
+    it('should not replace audience ids if no audience found', async () => {
+        const newFeatureConfigs = await replaceIdsInTargetingWithNames(featureConfigs as any, [])
+        expect(newFeatureConfigs[0].targets[0].audience.filters.filters[0]._audiences).to.deep.equal(['1'])
+    })
+})

--- a/src/utils/audiences/utils.test.ts
+++ b/src/utils/audiences/utils.test.ts
@@ -1,7 +1,8 @@
 import { expect } from '@oclif/test'
-import { replaceIdsInTargetingWithNames } from '.'
+import { buildAudienceNameMap, replaceAudienceIdInFilter } from '.'
+import { Audience, FeatureConfig, Filter, AudienceMatchFilter } from '../../api/schemas'
 
-describe.only('Audience Utils Test', () => {
+describe('Audience Utils Test', () => {
 
     const audiences = [
         {
@@ -13,59 +14,41 @@ describe.only('Audience Utils Test', () => {
             name: 'Audience 2'
         },
     ]
-    const featureConfigs = [
+    const filters = [
         {
-            '_feature': 'feature-id',
-            '_environment': 'environment-id',
-            '_createdBy': 'test',
-            'status': 'active',
-            'startedAt': '2023-07-05T19:43:45.076Z',
-            'updatedAt': '2023-07-05T19:50:06.329Z',
-            'targets': [
-                {
-                    '_id': '64a5c96e710da6dc8604994a',
-                    'name': 'Test Target',
-                    'audience': {
-                        'name': 'Test Audience',
-                        'filters': {
-                            'operator': 'and',
-                            'filters': [
-                                {
-                                    'type': 'audienceMatch',
-                                    '_audiences': [
-                                        '1'
-                                    ],
-                                    'comparator': '='
-                                },
-                                {
-                                    'type': 'user',
-                                    'subType': 'email',
-                                    'values': [
-                                        'new@email.com'
-                                    ],
-                                    'comparator': '='
-                                }
-                            ]
-                        }
-                    },
-                    'distribution': [
-                        {
-                            '_variation': '649f2ed02e588411dce577a9',
-                            'percentage': 1
-                        }
-                    ]
-                }
+            'type': 'audienceMatch',
+            '_audiences': [
+                '1'
             ],
-            'readonly': false
+            'comparator': '='
+        },
+        {
+            'type': 'user',
+            'subType': 'email',
+            'values': [
+                'new@email.com'
+            ],
+            'comparator': '='
         }
     ]
+    const audienceNameMap = buildAudienceNameMap(audiences as Audience[])
+
+    it('should build a map of audience ids to audience names', () => {
+        expect(audienceNameMap).to.deep.equal({
+            '1': 'Audience 1',
+            '2': 'Audience 2'
+        })
+    })
+
     it('should replace audience ids with audience names', async () => {
-        const newFeatureConfigs = await replaceIdsInTargetingWithNames(featureConfigs as any, audiences as any)
-        expect(newFeatureConfigs[0].targets[0].audience.filters.filters[0]._audiences).to.deep.equal(['Audience 1'])
+        const replacedIdFilter = 
+            replaceAudienceIdInFilter(filters[0] as AudienceMatchFilter, audienceNameMap) as AudienceMatchFilter
+        expect(replacedIdFilter._audiences).to.deep.equal(['Audience 1'])
     })
 
     it('should not replace audience ids if no audience found', async () => {
-        const newFeatureConfigs = await replaceIdsInTargetingWithNames(featureConfigs as any, [])
-        expect(newFeatureConfigs[0].targets[0].audience.filters.filters[0]._audiences).to.deep.equal(['1'])
+        const noneReplacedIdFilter = 
+            replaceAudienceIdInFilter(filters[0] as AudienceMatchFilter, {}) as AudienceMatchFilter
+        expect(noneReplacedIdFilter._audiences).to.deep.equal(['1'])
     })
 })


### PR DESCRIPTION
# Changes

- handle audience match filter when rendering targeting list
- added audiences to constructor of list option classes to prevent fetching in multiple places