### PR TITLE
chore: make targeting update command behave the same as other update commands

### DIFF
--- a/docs/targeting.md
+++ b/docs/targeting.md
@@ -111,13 +111,15 @@ Update Targeting rules for a Feature. The definition is the audience for the fea
 USAGE
   $ dvc targeting update [FEATURE] [ENVIRONMENT] [--config-path <value>] [--auth-path <value>] [--repo-config-path
     <value>] [--client-id <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--targets
-    <value>]
+    <value>] [--status enable|disable]
 
 ARGUMENTS
   FEATURE      The Feature for the Targeting Rule.
   ENVIRONMENT  The Environment where the Targeting Rule will be updated.
 
 FLAGS
+  --status=<option>  The status to set the targeting rule to.
+                     <options: enable|disable>
   --targets=<value>  List of targeting rules.
 
 GLOBAL FLAGS

--- a/docs/variations.md
+++ b/docs/variations.md
@@ -111,7 +111,7 @@ USAGE
     [--variables <value>] [--key <value>]
 
 ARGUMENTS
-  FEATURE  Feature key or id
+  FEATURE  Feature key or ID
   KEY
 
 FLAGS

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -347,6 +347,89 @@
             "bitbucket.code_usages",
             "cli"
           ]
+        }
+      },
+      "args": {}
+    },
+    "updateCommandWithCommonProperties": {
+      "id": "updateCommandWithCommonProperties",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": true,
+      "aliases": [],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli"
+          ]
         },
         "name": {
           "name": "name",
@@ -3063,6 +3146,16 @@
           "type": "option",
           "description": "List of targeting rules.",
           "multiple": false
+        },
+        "status": {
+          "name": "status",
+          "type": "option",
+          "description": "The status to set the targeting rule to.",
+          "multiple": false,
+          "options": [
+            "enable",
+            "disable"
+          ]
         }
       },
       "args": {
@@ -4001,7 +4094,7 @@
       "args": {
         "feature": {
           "name": "feature",
-          "description": "Feature key or id"
+          "description": "Feature key or ID"
         },
         "key": {
           "name": "key"

--- a/src/commands/environments/update.ts
+++ b/src/commands/environments/update.ts
@@ -8,11 +8,11 @@ import {
     environmentPrompt,
     EnvironmentPromptResult
 } from '../../ui/prompts'
-import UpdateCommand from '../updateCommand'
 import { Flags } from '@oclif/core'
 import { CreateEnvironmentDto, UpdateEnvironmentDto } from '../../api/schemas'
+import UpdateCommandWithCommonProperties from '../updateCommandWithCommonProperties'
 
-export default class UpdateEnvironment extends UpdateCommand {
+export default class UpdateEnvironment extends UpdateCommandWithCommonProperties {
     static hidden = false
     static description = 'Update a Environment.'
 
@@ -21,7 +21,7 @@ export default class UpdateEnvironment extends UpdateCommand {
         descriptionPrompt
     ]
     static flags = {
-        ...UpdateCommand.flags,
+        ...UpdateCommandWithCommonProperties.flags,
         'key': Flags.string({
             description: 'Unique ID'
         }),

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -6,19 +6,19 @@ import {
     keyPrompt,
     namePrompt,
 } from '../../ui/prompts'
-import UpdateCommand from '../updateCommand'
 import { Flags } from '@oclif/core'
 import { UpdateFeatureDto } from '../../api/schemas'
 import inquirer from '../../ui/autocomplete'
 import { VariableListOptions } from '../../ui/prompts/listPrompts/variablesListPrompt'
 import { VariationListOptions } from '../../ui/prompts/listPrompts/variationsListPrompt'
+import UpdateCommandWithCommonProperties from '../updateCommandWithCommonProperties'
 
-export default class UpdateFeature extends UpdateCommand {
+export default class UpdateFeature extends UpdateCommandWithCommonProperties {
     static hidden = false
     authRequired = true
     static description = 'Update a Feature.'
     static flags = {
-        ...UpdateCommand.flags,
+        ...UpdateCommandWithCommonProperties.flags,
         variables: Flags.string({
             description: 'The variables to set for the feature'
         }),

--- a/src/commands/targeting/update.test.ts
+++ b/src/commands/targeting/update.test.ts
@@ -235,18 +235,19 @@ describe('targeting update', () => {
         .stub(inquirer, 'registerPrompt', () => { return })
         .stub(inquirer, 'prompt', () => {
             let promptAnswers
-            if (promptCount < 3) {
+            if (promptCount < 5) {
                 promptAnswers =  {
+                    whichFields: ['targets'],
                     listPromptOption: 'edit',
                     targetListItem: { item: mockTargetingRule, id: 0 },
                     name: 'All Users New',
                     serve: { key: 'variation-off' },
                 }
-            } else if (promptCount === 3) {
+            } else if (promptCount === 5) {
                 promptAnswers = {
                     listPromptOption: 'add',
                 }
-            } else if (promptCount < 7) {
+            } else if (promptCount < 9) {
                 promptAnswers = {
                     type: 'user',
                     subType: 'user_id',
@@ -294,4 +295,3 @@ describe('targeting update', () => {
             expect(ctx.stdout).toMatchSnapshot()
         })
 })
-

--- a/src/commands/updateCommand.ts
+++ b/src/commands/updateCommand.ts
@@ -1,30 +1,10 @@
 import { Args, Flags } from '@oclif/core'
 import Base from './base'
 import { Prompt, handleCustomPrompts } from '../ui/prompts'
-import inquirer from 'inquirer'
 import { chooseFields } from '../utils/prompts'
 
 export default abstract class UpdateCommand extends Base {
     authRequired = true
-
-    static args = {
-        key: Args.string({
-            'key': Flags.string({
-                description: 'Unique ID',
-
-            }),
-            parse: async (input: string) => {
-                return input.toLowerCase()
-            }
-        }),
-    }
-
-    static flags = {
-        ...Base.flags,
-        'name': Flags.string({
-            description: 'Human readable name',
-        }),
-    }
 
     protected async populateParametersWithInquirer(prompts: Prompt[]) {
         if (!prompts.length) return {}

--- a/src/commands/updateCommandWithCommonProperties.ts
+++ b/src/commands/updateCommandWithCommonProperties.ts
@@ -1,0 +1,22 @@
+import UpdateCommand from './updateCommand'
+import { Args, Flags } from '@oclif/core'
+
+export default abstract class UpdateCommandWithCommonProperties extends UpdateCommand {
+    static args = {
+        key: Args.string({
+            'key': Flags.string({
+                description: 'Unique ID',
+            }),
+            parse: async (input: string) => {
+                return input.toLowerCase()
+            }
+        }),
+    }
+
+    static flags = {
+        ...UpdateCommand.flags,
+        'name': Flags.string({
+            description: 'Human readable name',
+        }),
+    }
+}

--- a/src/commands/variables/update.ts
+++ b/src/commands/variables/update.ts
@@ -9,11 +9,11 @@ import {
     namePrompt,
     variablePrompt,
 } from '../../ui/prompts'
-import UpdateCommand from '../updateCommand'
 import { Flags } from '@oclif/core'
 import { UpdateVariableDto } from '../../api/schemas'
+import UpdateCommandWithCommonProperties from '../updateCommandWithCommonProperties'
 
-export default class UpdateVariable extends UpdateCommand {
+export default class UpdateVariable extends UpdateCommandWithCommonProperties {
     static hidden = false
     static description = 'Update a Variable.'
 
@@ -24,7 +24,7 @@ export default class UpdateVariable extends UpdateCommand {
     ]
 
     static flags = {
-        ...UpdateCommand.flags,
+        ...UpdateCommandWithCommonProperties.flags,
         'description': Flags.string({
             description: 'Description for the variable',
         }),

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -1,5 +1,4 @@
 import inquirer from 'inquirer'
-import UpdateCommand from '../updateCommand'
 import { fetchVariationByKey, updateVariation, UpdateVariationParams } from '../../api/variations'
 import { featurePrompt, FeaturePromptResult, keyPrompt, namePrompt } from '../../ui/prompts'
 import { Feature, Variable } from '../../api/schemas'
@@ -11,8 +10,9 @@ import {
 } from '../../ui/prompts/variationPrompts'
 import { Args, Flags } from '@oclif/core'
 import { fetchFeatureByKey } from '../../api/features'
+import UpdateCommandWithCommonProperties from '../updateCommandWithCommonProperties'
 
-export default class UpdateVariation extends UpdateCommand {
+export default class UpdateVariation extends UpdateCommandWithCommonProperties {
     static hidden = false
     authRequired = true
     static description = 'Update a Variation.'
@@ -25,13 +25,13 @@ export default class UpdateVariation extends UpdateCommand {
     static args = {
         feature: Args.string({
             name: 'feature',
-            description: 'Feature key or id'
+            description: 'Feature key or ID'
         }),
-        ...UpdateCommand.args
+        ...UpdateCommandWithCommonProperties.args
     }
 
     static flags = {
-        ...UpdateCommand.flags,
+        ...UpdateCommandWithCommonProperties.flags,
         'variables': Flags.string({
             description: 'The variables to create for the variation'
         }),

--- a/src/ui/prompts/listPrompts/filterListPrompt.ts
+++ b/src/ui/prompts/listPrompts/filterListPrompt.ts
@@ -172,6 +172,10 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
 
     async printListOptions(list?: ListOption<Filter>[]) {
         const listToPrint = list || this.list
+        if (listToPrint.length === 0) {
+            this.writer.infoMessage(`No existing ${this.itemType}s.`)
+            return
+        }
         this.writer.blankLine()
         this.writer.title(this.messagePrompt)
         this.writer.infoMessage(`Current ${this.itemType}s:`)

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -166,6 +166,10 @@ export abstract class ListOptionsPrompt<T> {
      */
     async printListOptions(list?: ListOption<T>[]) {
         const listToPrint = list || this.list
+        if (listToPrint.length === 0) {
+            this.writer.infoMessage(`No existing ${this.itemType}s.`)
+            return
+        }
         this.writer.blankLine()
         this.writer.title(this.messagePrompt)
         this.writer.infoMessage(`Current ${this.itemType}s:`)

--- a/src/ui/prompts/listPrompts/targetingListPrompt.ts
+++ b/src/ui/prompts/listPrompts/targetingListPrompt.ts
@@ -9,7 +9,7 @@ import {
     ReorderItemPrompt
 } from './promptOptions'
 import { servePrompt } from '../targetingPrompts'
-import { Filters, UpdateTargetParams, Variation } from '../../../api/schemas'
+import { UpdateTargetParams, Variation } from '../../../api/schemas'
 import { FilterListOptions } from './filterListPrompt'
 import Writer from '../../writer'
 import { renderRulesTree } from '../../targetingTree'
@@ -30,6 +30,14 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
         this.authToken = authToken
         this.projectKey = projectKey
     }
+
+    getTargetingListPrompt = () => ({
+        name: 'targets', 
+        value: 'targets', 
+        message: 'Manage Targeting Rules',
+        type: 'listOptions',
+        listOptionsPrompt: () => this.prompt()
+    })
 
     options() {
         return [
@@ -119,6 +127,10 @@ export class TargetingListOptions extends ListOptionsPrompt<UpdateTargetParams> 
 
     async printListOptions(list?: ListOption<UpdateTargetParams>[]) {
         const listToPrint = list || this.list
+        if (listToPrint.length === 0) {
+            this.writer.infoMessage(`No existing ${this.itemType}s.`)
+            return
+        }
         this.writer.blankLine()
         this.writer.title(this.messagePrompt)
         this.writer.infoMessage(`Current ${this.itemType}s:`)

--- a/src/ui/prompts/listPrompts/variablesListPrompt.ts
+++ b/src/ui/prompts/listPrompts/variablesListPrompt.ts
@@ -17,7 +17,7 @@ export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams>
         type: 'listOptions',
         listOptionsPrompt: () => this.prompt()
     })
- 
+
     async promptAddItem(): Promise<ListOption<CreateVariableParams>> {
         const variable = await inquirer.prompt(this.variablePropertyPrompts)
         CreateVariableDto.parse(variable, { errorMap })

--- a/src/ui/prompts/targetingPrompts.ts
+++ b/src/ui/prompts/targetingPrompts.ts
@@ -11,6 +11,16 @@ export const comparatorChoices = (input: Record<string, any>) => {
     return ['=', '!=', 'exist', '!exist', 'contain', '!contain']
 }
 
+export const targetingStatusPrompt = {
+    name: 'status',
+    message: 'Status for the environment',
+    type: 'list',
+    choices: [
+        { name: 'enable', value: 'active' },
+        { name: 'disable', value: 'inactive' }
+    ],
+}
+
 export const servePrompt = {
     name: 'serve',
     message: 'Variation to serve',


### PR DESCRIPTION
# Changes
* Update `targeting update` test
* Change `targeting update` command to use `populateParametersWithZod`
* Can now also update the env status from the `targeting update` command