### PR TITLE
feat: support setting audienceMatch as a filter from list of existing audiences

### DIFF
--- a/src/ui/prompts/listPrompts/filterListPrompt.ts
+++ b/src/ui/prompts/listPrompts/filterListPrompt.ts
@@ -7,7 +7,8 @@ import {
     filterDataKeyTypePrompt,
     filterSubTypePrompt,
     filterTypePrompt,
-    filterValuesPrompt
+    filterValuesPrompt,
+    reusableAudienceFilterPrompt
 } from '../targetingPrompts'
 import { Audience, Filter } from '../../../api/schemas'
 import { Prompt } from '../types'
@@ -38,9 +39,14 @@ export class FilterListOptions extends ListOptionsPrompt<Filter> {
                 value: { item: filter }
             }
         } else if (type === 'audienceMatch') {
-            const { comparator, audiences } = await inquirer.prompt([filterComparatorPrompt, filterAudiencesPrompt])
-            const audiencesList = audiences.split(',').map((audience: string) => audience.trim())
-            const filter = { type: 'audienceMatch' as const, comparator, _audiences: audiencesList }
+            const { comparator, reusableAudiences } = await inquirer.prompt(
+                [
+                    filterComparatorPrompt, 
+                    reusableAudienceFilterPrompt(this.audiences)
+                ]
+            )
+            const reusableAudiencesList = reusableAudiences.map((audience: Audience) => audience._id)
+            const filter = { type: 'audienceMatch' as const, comparator, _audiences: reusableAudiencesList }
             return {
                 name: JSON.stringify(filter),
                 value: { item: filter }

--- a/src/ui/prompts/targetingPrompts.ts
+++ b/src/ui/prompts/targetingPrompts.ts
@@ -1,3 +1,4 @@
+import { Audience } from '../../api/schemas'
 import { DataKeyType, filterTypes, userSubTypes } from '../../api/targeting'
 import { isRequired } from '../../utils/validators'
 import { variationChoices } from './variationPrompts'
@@ -63,6 +64,16 @@ export const filterAudiencesPrompt = {
     suffix: ':',
     type: 'input'
 }
+
+export const reusableAudienceFilterPrompt = (audiences: Audience[]) => ({
+    name: 'reusableAudiences',
+    message: 'List of reusable audiences',
+    type: 'checkbox',
+    choices: audiences.map((audience: Audience) => ({
+        name: audience.name,
+        value: audience
+    }))
+})
 
 export const filterDataKeyPrompt = {
     name: 'dataKey',


### PR DESCRIPTION
# Changes

- Added support in filter list options prompt class to select `audienceMatch` filter values based on existing audiences 