### PR TITLE
chore: order env list by type in development, staging, production order

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ npm install -g @devcycle/cli
 $ dvc COMMAND
 running command...
 $ dvc (--version)
-@devcycle/cli/4.6.3 linux-x64 node-v18.16.0
+@devcycle/cli/4.6.3 darwin-arm64 node-v18.16.0
 $ dvc --help [COMMAND]
 USAGE
   $ dvc COMMAND

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -13,8 +13,11 @@ Generate Variable Types from the management API
 USAGE
   $ dvc generate types [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--output-dir <value>] [--react]
+    [--old-repos]
 
 FLAGS
+  --old-repos           Generate types for use with old DevCycle repos (@devcycle/devcycle-react-sdk,
+                        @devcycle/devcycle-js-sdk)
   --output-dir=<value>  [default: .] Directory to output the generated types to
   --react               Generate types for use with React
 

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.6.2",
+  "version": "4.6.3",
   "commands": {
     "authCommand": {
       "id": "authCommand",
@@ -1852,6 +1852,12 @@
           "name": "react",
           "type": "boolean",
           "description": "Generate types for use with React",
+          "allowNo": false
+        },
+        "old-repos": {
+          "name": "old-repos",
+          "type": "boolean",
+          "description": "Generate types for use with old DevCycle repos (@devcycle/devcycle-react-sdk, @devcycle/devcycle-js-sdk)",
           "allowNo": false
         }
       },

--- a/src/ui/prompts/environmentPrompts.ts
+++ b/src/ui/prompts/environmentPrompts.ts
@@ -16,6 +16,13 @@ export type EnvironmentPromptResult = {
     environment: EnvironmentChoice['value']
 } & PromptResult
 
+const EnvironmentTypeValue: Record<string, number> = {
+    development: 0,
+    staging: 1,
+    production: 2,
+    disaster_recovery: 3,
+}
+
 let choices: { name: string, value: Environment }[]
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const environmentChoices = async (input: Record<string, any>, search: string):Promise<EnvironmentChoice[]> => {
@@ -27,7 +34,7 @@ export const environmentChoices = async (input: Record<string, any>, search: str
                 name,
                 value: environment,
             }
-        })
+        }).sort((a, b) => EnvironmentTypeValue[a.value.type] - EnvironmentTypeValue[b.value.type])
     }
     return autocompleteSearch(choices, search)
 }


### PR DESCRIPTION
# Changes

- order environment list when prompted to be in order of `development`, `staging`, `production` types.