### PR TITLE
feat: Use refresh token to fetch new token for sso auth

### DIFF
--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.6.3",
+  "version": "4.6.4",
   "commands": {
     "authCommand": {
       "id": "authCommand",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest && oclif readme --multi",
-    "test": "mocha test/*.ts src/**/*.test.ts",
+    "test": "mocha test/*.ts \"src/**/*.test.ts\"",
     "test:ci": "yarn test --forbid-only",
     "version": "oclif readme --multi && git add README.md",
     "build:watch": "watch 'yarn build' src"

--- a/src/auth/TokenCache.ts
+++ b/src/auth/TokenCache.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import * as crypto from 'crypto'
 import fs from '../utils/fileSystem'
+import { getTokenExpiry } from './utils'
 
 export class TokenCache {
     filePath: string
@@ -16,8 +17,7 @@ export class TokenCache {
     public set(clientId: string, clientSecret: string, token: string): void {
         try {
             const identifier = this.hashCredentials(clientId, clientSecret)
-            const tokenPayload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString())
-            const expiry = tokenPayload.exp * 1000
+            const expiry = getTokenExpiry(token)
             fs.writeFileSync(this.filePath, JSON.stringify({ identifier, token, expiry }))
         } catch (err) {
             // don't throw error

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -19,6 +19,10 @@ export class ClientCredentialsAuthConfig {
 export class SSOAuthConfig {
     @IsString()
     accessToken: string
+
+    @IsString()
+    @IsOptional()
+    refreshToken?: string
 }
 
 export class AuthConfig {
@@ -33,12 +37,12 @@ export class AuthConfig {
     sso?: SSOAuthConfig
 }
 
-export function storeAccessToken(accessToken: string, authPath: string): void {
+export function storeAccessToken(tokens: SSOAuthConfig, authPath: string): void {
     const configDir = path.dirname(authPath)
     if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true })
     }
     const config = new AuthConfig()
-    config.sso = { accessToken }
+    config.sso = tokens
     fs.writeFileSync(authPath, jsYaml.dump(config))
 }

--- a/src/auth/utils/getTokenExpiry.test.ts
+++ b/src/auth/utils/getTokenExpiry.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert'
+import { getTokenExpiry } from './getTokenExpiry'
+
+describe('getTokenExpiry', () => {
+    it('parses expiry when it exists', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlhpTzk1Xzllbk53Z1NNSkZRSXZNUiJ9.eyJodHRwczovL2RldmN5Y2xlLmNvbS9lbWFpbCI6InRlc3RAdGFwbHl0aWNzLmNvbSIsImh0dHBzOi8vZGV2Y3ljbGUuY29tL2lzR2VuZXJpY0RvbWFpbiI6ZmFsc2UsImh0dHBzOi8vZGV2Y3ljbGUuY29tL2FsbG93T3JnRGlzY292ZXJ5Ijp0cnVlLCJpc3MiOiJodHRwczovL2F1dGguZGV2Y3ljbGUuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTExNTU5MDA2NTYzMzMzMzM0MjE0IiwiYXVkIjoiaHR0cHM6Ly9hcGkuZGV2Y3ljbGUuY29tLyIsImlhdCI6MTY4Nzk2NjU0MiwiZXhwIjo5OTk5OTk5OTk5LCJhenAiOiJFdjlKMERHeFIzS2hyS2Fad1k2amxjY21qbDdKR0tFWCIsIm9yZ19pZCI6Im9yZ19VOUY4WU1hVENoVEVuZFd3IiwicGVybWlzc2lvbnMiOlsiY3JlYXRlOnJlc291cmNlcyIsImRlbGV0ZTpyZXNvdXJjZXMiLCJyZWFkOmN1cnJlbnRfb3JnYW5pemF0aW9uIiwicmVhZDpyZXNvdXJjZXMiLCJyZWFkOnVzZXJzIiwidXBkYXRlOnJlc291cmNlcyJdfQ==.bd8rLSYh6ZtnzEgG-Mya86wnOuZcRC97tb4_8gdjTgH2aUCkNRDKcJvLkFL_wYszBurFs75n-BdHKnv9H8yy23fdQbPxX-5Wjq1vvS5PN3DdpvGtc5EuumFBxgwUO3WTmId2znjbMBWIVOM5bViRN8Pba4X6XZSSQ6hxd7-30Txj_5dOsPNikZHjBDuTCqlQxdrZu_ER0JKKkRwdlR8h7qsGMBrTeVqBhIFQXQIFns440FZsCGaOK4hFw9vg6remaBu3HTQRWClXHVwh03lwFTX8MTfwRwFDGhl988zbzK38AAncoKcXKCMrG2GXVswar0RaQWhLSL9eLuX0PI99Ww'
+
+        const expiry = getTokenExpiry(token)
+
+        assert.equal(expiry, 9999999999000)
+    })
+
+    it('returns undefined when expiry does not exist', () => {
+        const token = 'not a jwt token'
+        const expiry = getTokenExpiry(token)
+
+        assert.equal(expiry, undefined)
+    })
+})

--- a/src/auth/utils/getTokenExpiry.ts
+++ b/src/auth/utils/getTokenExpiry.ts
@@ -1,0 +1,8 @@
+import { getTokenPayload } from './getTokenPayload'
+
+export const getTokenExpiry = (token: string) => {
+    const tokenPayload = getTokenPayload(token)
+    return tokenPayload
+        ? tokenPayload.exp * 1000
+        : undefined
+}

--- a/src/auth/utils/getTokenPayload.test.ts
+++ b/src/auth/utils/getTokenPayload.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert'
+import { getTokenPayload } from './getTokenPayload'
+
+describe('getTokenPayload', () => {
+    it('parses a valid jwt token', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlhpTzk1Xzllbk53Z1NNSkZRSXZNUiJ9.eyJodHRwczovL2RldmN5Y2xlLmNvbS9lbWFpbCI6InRlc3RAdGFwbHl0aWNzLmNvbSIsImh0dHBzOi8vZGV2Y3ljbGUuY29tL2lzR2VuZXJpY0RvbWFpbiI6ZmFsc2UsImh0dHBzOi8vZGV2Y3ljbGUuY29tL2FsbG93T3JnRGlzY292ZXJ5Ijp0cnVlLCJpc3MiOiJodHRwczovL2F1dGguZGV2Y3ljbGUuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTExNTU5MDA2NTYzMzMzMzM0MjE0IiwiYXVkIjoiaHR0cHM6Ly9hcGkuZGV2Y3ljbGUuY29tLyIsImlhdCI6MTY4Nzk2NjU0MiwiZXhwIjo5OTk5OTk5OTk5LCJhenAiOiJFdjlKMERHeFIzS2hyS2Fad1k2amxjY21qbDdKR0tFWCIsIm9yZ19pZCI6Im9yZ19VOUY4WU1hVENoVEVuZFd3IiwicGVybWlzc2lvbnMiOlsiY3JlYXRlOnJlc291cmNlcyIsImRlbGV0ZTpyZXNvdXJjZXMiLCJyZWFkOmN1cnJlbnRfb3JnYW5pemF0aW9uIiwicmVhZDpyZXNvdXJjZXMiLCJyZWFkOnVzZXJzIiwidXBkYXRlOnJlc291cmNlcyJdfQ==.bd8rLSYh6ZtnzEgG-Mya86wnOuZcRC97tb4_8gdjTgH2aUCkNRDKcJvLkFL_wYszBurFs75n-BdHKnv9H8yy23fdQbPxX-5Wjq1vvS5PN3DdpvGtc5EuumFBxgwUO3WTmId2znjbMBWIVOM5bViRN8Pba4X6XZSSQ6hxd7-30Txj_5dOsPNikZHjBDuTCqlQxdrZu_ER0JKKkRwdlR8h7qsGMBrTeVqBhIFQXQIFns440FZsCGaOK4hFw9vg6remaBu3HTQRWClXHVwh03lwFTX8MTfwRwFDGhl988zbzK38AAncoKcXKCMrG2GXVswar0RaQWhLSL9eLuX0PI99Ww'
+
+        const payload = getTokenPayload(token)
+
+        assert.equal(payload?.exp, 9999999999)
+    })
+
+    it('catches parsing errors and returns undefined for invalid token', () => {
+        const token = 'not a jwt token'
+        const payload = getTokenPayload(token)
+
+        assert.equal(payload, undefined)
+    })
+})

--- a/src/auth/utils/getTokenPayload.ts
+++ b/src/auth/utils/getTokenPayload.ts
@@ -1,0 +1,11 @@
+type TokenPayload = {
+    exp: number
+}
+
+export const getTokenPayload = (token: string): TokenPayload | undefined => {
+    try {
+        return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString())
+    } catch (err) {
+        return undefined
+    }
+}

--- a/src/auth/utils/index.ts
+++ b/src/auth/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getTokenExpiry'
+export * from './getTokenPayload'
+export * from './shouldRefreshToken'

--- a/src/auth/utils/shouldRefreshToken.test.ts
+++ b/src/auth/utils/shouldRefreshToken.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert'
+import { shouldRefreshToken } from './shouldRefreshToken'
+
+describe('shouldRefreshToken', () => {
+    it('returns false when expiry is in more than 1 hour', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.K_lUwtGbvjCHP8Ff-gW9GykydkkXzHKRPbACxItvrFU'
+        const shouldRefresh = shouldRefreshToken(token)
+
+        assert.equal(shouldRefresh, false)
+    })
+
+    it('returns true when expiry is in less than 1 hour', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2OTA1Njk3NDl9.tky9uXPkMNABH8JenyyIt_cHpcg51cIH25eWRk7le4g'
+        const shouldRefresh = shouldRefreshToken(token)
+
+        assert.equal(shouldRefresh, true)
+    })
+
+    it('returns true when token is invalid', () => {
+        // eslint-disable-next-line max-len
+        const token = 'not a real token'
+        const shouldRefresh = shouldRefreshToken(token)
+
+        assert.equal(shouldRefresh, true)
+    })
+})

--- a/src/auth/utils/shouldRefreshToken.ts
+++ b/src/auth/utils/shouldRefreshToken.ts
@@ -1,0 +1,9 @@
+import { getTokenExpiry } from './getTokenExpiry'
+
+export const shouldRefreshToken = (token: string): boolean => {
+    const tokenExpiry = getTokenExpiry(token)
+    if (!tokenExpiry) return true
+
+    const hoursToExpiry = (tokenExpiry - Date.now()) / 1000 / 60 / 60
+    return hoursToExpiry <= 1
+}

--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Flags } from '@oclif/core'
 import { fetchOrganizations, Organization } from '../api/organizations'
 import { fetchProjects } from '../api/projects'
-import SSOAuth from '../api/ssoAuth'
+import SSOAuth from '../auth/SSOAuth'
 import { storeAccessToken } from '../auth/config'
 import { promptForOrganization } from '../ui/promptForOrganization'
 import { promptForProject } from '../ui/promptForProject'
@@ -101,14 +101,14 @@ export default abstract class AuthCommand extends Base {
 
     async selectOrganization(organization: Organization): Promise<string> {
         const ssoAuth = new SSOAuth(this.writer)
-        const token = await ssoAuth.getAccessToken(organization)
+        const tokens = await ssoAuth.getAccessToken(organization)
         const { id, name, display_name } = organization
-        storeAccessToken(token, this.authPath)
+        storeAccessToken(tokens, this.authPath)
         if (this.repoConfig) {
             this.updateRepoConfig({ org: { id, name, display_name } })
         } else if (this.userConfig) {
             this.updateUserConfig({ org: { id, name, display_name } })
         }
-        return token
+        return tokens.accessToken
     }
 }

--- a/src/commands/login/sso.ts
+++ b/src/commands/login/sso.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import SSOAuth from '../../api/ssoAuth'
+import SSOAuth from '../../auth/SSOAuth'
 import AuthCommand from '../authCommand'
 
 export default class LoginSSO extends AuthCommand {
@@ -10,7 +10,8 @@ export default class LoginSSO extends AuthCommand {
 
     public async run(): Promise<void> {
         const ssoAuth = new SSOAuth(this.writer)
-        this.authToken = await ssoAuth.getAccessToken()
+        const tokens = await ssoAuth.getAccessToken()
+        this.authToken = tokens.accessToken
         await this.setOrganizationAndProject()
     }
 }

--- a/src/commands/repo/init.ts
+++ b/src/commands/repo/init.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 
 import { storeAccessToken } from '../../auth/config'
-import SSOAuth from '../../api/ssoAuth'
+import SSOAuth from '../../auth/SSOAuth'
 import AuthCommand from '../authCommand'
 
 export default class InitRepo extends AuthCommand {
@@ -17,8 +17,9 @@ export default class InitRepo extends AuthCommand {
         this.repoConfig = await this.updateRepoConfig({})
 
         const ssoAuth = new SSOAuth(this.writer)
-        this.authToken = await ssoAuth.getAccessToken()
-        storeAccessToken(this.authToken, this.authPath)
+        const tokens = await ssoAuth.getAccessToken()
+        this.authToken = tokens.accessToken
+        storeAccessToken(tokens, this.authPath)
 
         await this.setOrganizationAndProject()
     }


### PR DESCRIPTION
- When fetching a new token with sso auth retrieve a refresh token as well
- When a token is within 1 hour of expiry and we have a refresh token available, fetch a new token

This allows users to login through the browser once, and then as long as they interact with the CLI within the refresh token expiry (15 days) the access token will be refreshed