### PR TITLE
feat: Add organizations list command

### DIFF
--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -1,0 +1,30 @@
+`dvc organizations`
+===================
+
+List the keys of all organizations available to the current user
+
+* [`dvc organizations list`](#dvc-organizations-list)
+
+## `dvc organizations list`
+
+List the keys of all organizations available to the current user
+
+```
+USAGE
+  $ dvc organizations list [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  List the keys of all organizations available to the current user
+```

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.7.0",
+  "version": "4.7.1",
   "commands": {
     "authCommand": {
       "id": "authCommand",
@@ -2346,6 +2346,91 @@
           "type": "option",
           "description": "The `name` of the org to sign in as (not the `display_name`)",
           "multiple": false
+        }
+      },
+      "args": {}
+    },
+    "organizations:list": {
+      "id": "organizations:list",
+      "description": "List the keys of all organizations available to the current user",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli",
+            "vs_code_extension"
+          ]
         }
       },
       "args": {}

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -23,6 +23,10 @@ export class SSOAuthConfig {
     @IsString()
     @IsOptional()
     refreshToken?: string
+
+    @IsString()
+    @IsOptional()
+    personalAccessToken?: string
 }
 
 export class AuthConfig {
@@ -37,12 +41,16 @@ export class AuthConfig {
     sso?: SSOAuthConfig
 }
 
-export function storeAccessToken(tokens: SSOAuthConfig, authPath: string): void {
+export function storeAccessToken(tokens: Partial<SSOAuthConfig>, authPath: string): void {
     const configDir = path.dirname(authPath)
     if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true })
     }
     const config = new AuthConfig()
-    config.sso = tokens
+    config.sso = config.sso || new SSOAuthConfig()
+    if (tokens.accessToken) config.sso.accessToken = tokens.accessToken
+    if (tokens.refreshToken) config.sso.refreshToken = tokens.refreshToken
+    if (tokens.personalAccessToken) config.sso.personalAccessToken = tokens.personalAccessToken
+
     fs.writeFileSync(authPath, jsYaml.dump(config))
 }

--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -4,7 +4,6 @@ import { Flags } from '@oclif/core'
 import { fetchOrganizations, Organization } from '../api/organizations'
 import { fetchProjects } from '../api/projects'
 import SSOAuth from '../auth/SSOAuth'
-import { storeAccessToken } from '../auth/config'
 import { promptForOrganization } from '../ui/promptForOrganization'
 import { promptForProject } from '../ui/promptForProject'
 import Base from './base'
@@ -100,10 +99,10 @@ export default abstract class AuthCommand extends Base {
     }
 
     async selectOrganization(organization: Organization): Promise<string> {
-        const ssoAuth = new SSOAuth(this.writer)
+        const ssoAuth = new SSOAuth(this.writer, this.authPath)
         const tokens = await ssoAuth.getAccessToken(organization)
         const { id, name, display_name } = organization
-        storeAccessToken(tokens, this.authPath)
+
         if (this.repoConfig) {
             this.updateRepoConfig({ org: { id, name, display_name } })
         } else if (this.userConfig) {

--- a/src/commands/login/sso.ts
+++ b/src/commands/login/sso.ts
@@ -9,7 +9,7 @@ export default class LoginSSO extends AuthCommand {
     static examples = []
 
     public async run(): Promise<void> {
-        const ssoAuth = new SSOAuth(this.writer)
+        const ssoAuth = new SSOAuth(this.writer, this.authPath)
         const tokens = await ssoAuth.getAccessToken()
         this.authToken = tokens.accessToken
         await this.setOrganizationAndProject()

--- a/src/commands/organizations/list.ts
+++ b/src/commands/organizations/list.ts
@@ -1,0 +1,14 @@
+import { fetchOrganizations } from '../../api/organizations'
+import Base from '../base'
+
+export default class ListOrganizations extends Base {
+    static description = 'List the keys of all organizations available to the current user'
+    static hidden = false
+
+    userAuthRequired = true
+
+    public async run(): Promise<void> {
+        const orgs = await fetchOrganizations(this.personalAccessToken)
+        return this.writer.showResults(orgs.map((orgs) => orgs.name))
+    }
+}

--- a/src/commands/repo/init.ts
+++ b/src/commands/repo/init.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata'
 
-import { storeAccessToken } from '../../auth/config'
 import SSOAuth from '../../auth/SSOAuth'
 import AuthCommand from '../authCommand'
 
@@ -16,10 +15,9 @@ export default class InitRepo extends AuthCommand {
 
         this.repoConfig = await this.updateRepoConfig({})
 
-        const ssoAuth = new SSOAuth(this.writer)
+        const ssoAuth = new SSOAuth(this.writer, this.authPath)
         const tokens = await ssoAuth.getAccessToken()
         this.authToken = tokens.accessToken
-        storeAccessToken(tokens, this.authPath)
 
         await this.setOrganizationAndProject()
     }


### PR DESCRIPTION
Add organizations list command. This requires a personal access token rather than an org specific token, which we typically fetch upon login.
- Add `personalAccessToken` property to AuthConfig sso object so that token can be reused on subsequent requests
- If a command requires a personalAccessToken and it does not exist, trigger sso flow to get token