### PR TITLE
fix: exclude context lines from git diff

### DIFF
--- a/src/utils/diff/diff.ts
+++ b/src/utils/diff/diff.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs'
 
 export const executeDiff = (diffCommand: string): parse.File[] => {
     try {
-        execSync(`git diff ${diffCommand} > diff.txt`, { stdio: 'ignore' })
+        execSync(`git diff --unified=0 ${diffCommand} > diff.txt`, { stdio: 'ignore' })
         return parse(readFileSync('diff.txt', 'utf8'))
     } finally {
         execSync('rm diff.txt', { stdio: 'ignore' })


### PR DESCRIPTION
If there are more than 0 lines of context returned by `git diff', the CLI will also detect these context lines as changes, even though these lines have not been modified.
I noticed this bug while using the [feature-flag-pr-insights-action](https://github.com/DevCycleHQ/feature-flag-pr-insights-action). Some pull requests were commented by the action with variable changes (added and removed at the same time, but that is another issue), but the variables were not touched in the PR.