### PR TITLE
feat: Use org and project from repo config if it exists

### DIFF
--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.0",
+  "version": "5.2.1",
   "commands": {
     "authCommand": {
       "id": "authCommand",

--- a/src/auth/utils/getOrgIdFromToken.test.ts
+++ b/src/auth/utils/getOrgIdFromToken.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert'
+import { getOrgIdFromToken } from './getOrgIdFromToken'
+
+describe('getOrgIdFromToken', () => {
+    it('parses "org_id" when it exists', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJvcmdfaWQiOiJvcmdBQkMifQ.FDLOcz96JfcVLJZZdfJ9OtW5EzLmVVHS7u4usjJYJ6g'
+
+        const orgId = getOrgIdFromToken(token)
+
+        assert.equal(orgId, 'orgABC')
+    })
+
+    it('parses "https://devcycle.com/org_id" when it exists', () => {
+        // eslint-disable-next-line max-len
+        const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJodHRwczovL2RldmN5Y2xlLmNvbS9vcmdfaWQiOiJvcmcxMjMifQ.bV7-ZTb8HqYhjWLSz9yQyycmzBkZrm9Nexw03zvI0DE'
+
+        const orgId = getOrgIdFromToken(token)
+
+        assert.equal(orgId, 'org123')
+    })
+
+    it('returns undefined when org id does not exist', () => {
+        const token = 'not a jwt token'
+        const orgId = getOrgIdFromToken(token)
+
+        assert.equal(orgId, undefined)
+    })
+})

--- a/src/auth/utils/getOrgIdFromToken.ts
+++ b/src/auth/utils/getOrgIdFromToken.ts
@@ -1,0 +1,6 @@
+import { getTokenPayload } from './getTokenPayload'
+
+export const getOrgIdFromToken = (token: string): string | undefined => {
+    const payload = getTokenPayload(token)
+    return payload?.org_id || payload?.['https://devcycle.com/org_id']
+}

--- a/src/auth/utils/getTokenPayload.ts
+++ b/src/auth/utils/getTokenPayload.ts
@@ -1,5 +1,7 @@
 type TokenPayload = {
     exp: number
+    'https://devcycle.com/org_id'?: string // client credential tokens
+    org_id?: string // user sso tokens
 }
 
 export const getTokenPayload = (token: string): TokenPayload | undefined => {

--- a/src/auth/utils/index.ts
+++ b/src/auth/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './getTokenExpiry'
 export * from './getTokenPayload'
 export * from './shouldRefreshToken'
+export * from './getOrgIdFromToken'

--- a/src/commands/alias/add.ts
+++ b/src/commands/alias/add.ts
@@ -7,7 +7,6 @@ const VARIABLE_DESCRIPTION = 'The DevCycle variable key'
 
 export default class AddAlias extends Base {
     static hidden = false
-    runsInRepo = true
     static description = 'Add a variable alias to the repo configuration'
     static flags = {
         ...Base.flags,

--- a/src/commands/cleanup/index.ts
+++ b/src/commands/cleanup/index.ts
@@ -18,7 +18,6 @@ import {
 
 export default class Cleanup extends Base {
     static hidden = false
-    runsInRepo = true
 
     static description = 'Replace a DevCycle variable with a static value in the current version of your code. ' +
         'Currently only JavaScript is supported.'

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -45,7 +45,6 @@ type MatchesByTypeEnriched = {
 export default class Diff extends Base {
     static hidden = false
     authSuggested = true
-    runsInRepo = true
 
     static description = 'Print a diff of DevCycle variable usage between two versions of your code.'
     static examples = [

--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -15,7 +15,6 @@ import { Variable } from '../../api/schemas'
 
 export default class Usages extends Base {
     static hidden = false
-    runsInRepo = true
 
     static description = 'Print all DevCycle variable usages in the current version of your code.'
     static examples = [


### PR DESCRIPTION
When running any command within the context of a repo, if an org and project exist in the repo config use those.
- Update auth file to store tokens by org ID, so that user can switch between repos seamlessly

This is required to unblock the [multi-folder case for the vs code extension](https://taplytics.atlassian.net/browse/DVC-8462)