### PR TITLE
fix: Update org select command to require user auth

### DIFF
--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -18,7 +18,7 @@ export default abstract class AuthCommand extends Base {
 
     public async setOrganization(): Promise<void> {
         const { flags } = await this.parse(AuthCommand)
-        const organizations = await fetchOrganizations(this.authToken)
+        const organizations = await fetchOrganizations(this.personalAccessToken)
         if (flags.headless && !flags.org) {
             throw new Error('In headless mode, org flag is required')
         }

--- a/src/commands/organizations/select.ts
+++ b/src/commands/organizations/select.ts
@@ -3,7 +3,7 @@ import AuthCommand from '../authCommand'
 export default class SelectOrganization extends AuthCommand {
     static description = 'Select which organization to access through the API'
     static hidden = false
-    authRequired = true
+    userAuthRequired = true
 
     public async run(): Promise<void> {
         await this.setOrganizationAndProject()


### PR DESCRIPTION
Selecting an org requires user auth (rather than client credential), update the command class to require this and use the correct token