### PR TITLE
Prompt for variation values when updating feature variables

### DIFF
--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -293,7 +293,7 @@ const CreateVariableDto = z.object({
         .regex(/^[a-z0-9-_.]+$/),
     _feature: z.string().optional(),
     type: z.enum(['String', 'Boolean', 'Number', 'JSON']),
-    defaultValue: z.object({}).partial().optional(),
+    defaultValue: z.any().optional(),
     validationSchema: VariableValidationEntity.optional(),
 })
 const Variable = z.object({
@@ -308,7 +308,7 @@ const Variable = z.object({
     _feature: z.string().optional(),
     type: z.enum(['String', 'Boolean', 'Number', 'JSON']),
     status: z.enum(['active', 'archived']),
-    defaultValue: z.object({}).partial().optional(),
+    defaultValue: z.any().optional(),
     source: z.enum([
         'api',
         'dashboard',

--- a/src/commands/features/__snapshots__/update.test.ts.snap
+++ b/src/commands/features/__snapshots__/update.test.ts.snap
@@ -75,6 +75,9 @@ exports[`features update updates a feature after prompting for all fields 1`] = 
 }
 
 
+🤖 No existing Variations.
+🤖 No existing Variations.
+----------------------------------------
 {
   \\"name\\": \\"Feature Name\\",
   \\"key\\": \\"feature-key\\",

--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -50,7 +50,8 @@ describe('features update', () => {
         name: 'New Feature Name',
         key: 'new-feature-key',
         description: 'test description',
-        sdkVisibility: testSDKVisibility
+        sdkVisibility: testSDKVisibility,
+        variations: [],
     }
 
     const requestBodyWithVariables = {

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -64,7 +64,13 @@ export default class UpdateFeature extends UpdateCommandWithCommonProperties {
 
         this.writer.printCurrentValues(feature)
 
-        this.prompts.push((new VariableListOptions(feature.variables ?? [], this.writer)).getVariablesListPrompt())
+        const variableListOptions = new VariableListOptions(
+            feature.variables ?? [], 
+            this.writer, 
+            !variations ? feature.variations: undefined // don't prompt for variable values if variations flag provided
+        )
+
+        this.prompts.push(variableListOptions.getVariablesListPrompt())
         this.prompts.push(
             (
                 new VariationListOptions(
@@ -86,6 +92,9 @@ export default class UpdateFeature extends UpdateCommandWithCommonProperties {
             ...(sdkVisibility ? { sdkVisibility: JSON.parse(sdkVisibility) } : {}),
             headless,
         })
+        // if variations were set by the variations list option or flag, 
+        // they should override the variations set by the variables list option
+        params.variations = params.variations || variableListOptions.featureVariations
 
         const result = await updateFeature(this.authToken, this.projectKey, feature.key, params)
         this.writer.showResults(result)

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -1,4 +1,4 @@
-import { CreateVariableDto, Variable } from '../../api/schemas'
+import { CreateVariableDto, Variable, Variation } from '../../api/schemas'
 import { fetchVariables } from '../../api/variables'
 import { AutoCompletePrompt, Prompt, PromptResult } from '.'
 import chalk from 'chalk'
@@ -122,6 +122,23 @@ export const variableValueJSONPrompt = (variableKey: string, defaultValue?: stri
                 return 'Please enter a valid JSON object'
             }
         }
+    }
+}
+
+export const getVariableValuePrompt = (
+    variation: Variation, 
+    variableType: 'String' | 'Boolean' | 'Number' | 'JSON',
+    defaultValue?: string | number | boolean
+) => {
+    switch (variableType) {
+        case 'Boolean':
+            return variableValueBooleanPrompt(variation.key, defaultValue as boolean | undefined)
+        case 'Number':
+            return variableValueNumberPrompt(variation.key, defaultValue as number | undefined)
+        case 'JSON':
+            return variableValueJSONPrompt(variation.key, defaultValue as string | undefined)
+        default:
+            return variableValueStringPrompt(variation.key, defaultValue as string | undefined)
     }
 }
 


### PR DESCRIPTION
- fix the zod schema so that it knows CreateVariableDTO.defaultValue is optional 
- add a prompt for variation values when adding or updating a variable on an existing feature

note: this is a little bit sketchy because when updating the variables list, we need to essentially update the feature variations list as a semi-related side effect. Because the functions on VariableListOptions have to return a valid list option, i couldn't figure out a cleaner way to update the feature variations than to store them on the VariableListOptions class and access them in the feature update command separately. if there's a better way let me know!!

New prompts when editing a variable within a feature update:
<img width="358" alt="image" src="https://github.com/DevCycleHQ/cli/assets/25067948/ad290824-d7f2-48ce-bd34-7bb81c38bc39">

this prompt won't show up when updating a single variable outside of a feature, or if you select variables _and_ variations from the chooseFields prompt (since the variations prompt will already ask for the variable values). 