### PR TITLE
chore: Add build artifacts to release

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -26,6 +26,7 @@ runs:
     # Replace with DevCycleHQ/release-action/gh-release@main when it's ready
     - name: Create GitHub Release
       uses: ncipollo/release-action@v1
+      id: create_release
       with:
         name: "${{ inputs.release-tag }}"
         tag: "${{ inputs.release-tag }}"
@@ -34,6 +35,55 @@ runs:
         token: ${{ inputs.github-token }}
         draft: ${{ inputs.draft }}
         prerelease: ${{ inputs.prerelease }}
+
+    - name: Build Artifacts
+      shell: bash
+      run: yarn build:tar
+
+    - name: Get Path of Linux Artifact
+      id: linux_artifact
+      shell: bash
+      run: |
+        echo "ARTIFACT_PATH=$(ls dist/*-linux-arm.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Upload Linux Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.linux_artifact.outputs.ARTIFACT_PATH }}
+        asset_name: dvc-${{ inputs.release-tag }}-linux-arm.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Get Path of Windows Artifact
+      id: windows_artifact
+      shell: bash
+      run: |
+        echo "ARTIFACT_PATH=$(ls dist/*-win32-x64.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Upload Windows Artifacts
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.windows_artifact.outputs.ARTIFACT_PATH }}
+        asset_name: dvc-${{ inputs.release-tag }}-win32-x64.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Get Path of Darwin Artifact
+      id: darwin_artifact
+      shell: bash
+      run: |
+        echo "ARTIFACT_PATH=$(ls dist/*-darwin-arm64.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Upload Darwin Artifacts
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.darwin_artifact.outputs.ARTIFACT_PATH }}
+        asset_name: dvc-${{ inputs.release-tag }}-darwin-arm64.tar.gz
+        asset_content_type: application/gzip
         
     - name: Publish to NPM
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 .vscode
 .prettierrc
+tmp

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -90,11 +90,10 @@ Update a Variable.
 USAGE
   $ dvc variables update [KEY] [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--name <value>] [--description
-    <value>] [--feature <value>]
+    <value>]
 
 FLAGS
   --description=<value>  Description for the variable
-  --feature=<value>      The ID of the feature to associate the variable to
   --name=<value>         Human readable name
 
 GLOBAL FLAGS

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "scripts": {
     "build": "shx rm -rf dist && tsc -b && oclif manifest && oclif readme --multi",
+    "build:tar": "oclif pack tarballs",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",


### PR DESCRIPTION
- Use oclif command to pack tarballs (including node binary)
- Update release action to build and upload packaged artifacts (these will be used by the vscode extension)