### PR TITLE
fix: Pass all errors to oclif error handler after custom handling

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -93,10 +93,13 @@ export default abstract class Base extends Command {
     writer: Writer = new Writer()
 
     async catch(error: unknown) {
-        if (error instanceof ZodError) {
-            this.reportZodValidationErrors(error)
-        } else if (error instanceof Error) {
-            this.writer.showError(error.message)
+        if (error instanceof Error) {
+            if (error instanceof ZodError) {
+                this.reportZodValidationErrors(error)
+            } else {
+                this.writer.showError(error.message)
+            }
+            throw error
         }
     }
     private async authorizeApi(): Promise<void> {

--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -70,12 +70,13 @@ describe('diff', () => {
                 message: 'Failed auth'
             })
         })
-        .stdout()
+        .stderr()
         .command(['diff', '--file',
             './test-utils/fixtures/diff/e2e',
             '--client-id', 'client', '--client-secret', 'secret', '--project', 'project'])
+        .catch((err) => null)
         .it('runs with failed api authorization', (ctx) => {
-            expect(ctx.stdout).to.contain('Failed to authenticate with the DevCycle API. Check your credentials.')
+            expect(ctx.stderr).to.contain('Failed to authenticate with the DevCycle API. Check your credentials.')
         })
 
     test

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -77,7 +77,7 @@ describe('features create', () => {
 
     // Headless mode
     dvcTest()
-        .stdout()
+        .stderr()
         .command([
             'features create',
             '--project', projectKey,
@@ -85,10 +85,9 @@ describe('features create', () => {
             '--headless',
             ...authFlags
         ])
-        .it('Errors when called in headless mode with no key',
-            (ctx) => {
-                expect(ctx.stdout).to.contain('The key and name flags are required')
-            })
+        .it('Errors when called in headless mode with no key', (ctx) => {
+            expect(ctx.stderr).to.contain('The key and name flags are required')
+        })
     
     dvcTest()
         .nock(BASE_URL, (api) => api
@@ -219,19 +218,17 @@ describe('features create', () => {
             .get(`/v1/projects/${projectKey}`)
             .reply(200, mockProject)
         )
-        .stdout()
+        .stderr()
         .command([
             'features create',
             '--project', projectKey,
             '-i',
             ...authFlags
         ])
-        .it('returns an error if key is not provided',
-            (ctx) => {
-                expect(ctx.stdout).to.contain(
-                    'key is a required field'
-                )
-            })
+        .catch((err) => null)
+        .it('returns an error if key is not provided', (ctx) => {
+            expect(ctx.stderr).to.contain('key is a required field')
+        })
     
     dvcTest()
         .stub(inquirer, 'prompt', () => ({
@@ -244,19 +241,17 @@ describe('features create', () => {
             .get(`/v1/projects/${projectKey}`)
             .reply(200, mockProject)
         )
-        .stdout()
+        .stderr()
         .command([
             'features create',
             '--project', projectKey,
             '-i',
             ...authFlags
         ])
-        .it('returns an error if name is not provided',
-            (ctx) => {
-                expect(ctx.stdout).to.contain(
-                    'name is a required field'
-                )
-            })
+        .catch((err) => null)
+        .it('returns an error if name is not provided', (ctx) => {
+            expect(ctx.stderr).to.contain('name is a required field')
+        })
 
     dvcTest()
         .stub(inquirer, 'prompt', () => ({

--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -88,7 +88,7 @@ describe('features update', () => {
         )
 
     dvcTest()
-        .stdout()
+        .stderr()
         .command([
             'features update',
             '--project', projectKey,
@@ -102,7 +102,7 @@ describe('features update', () => {
         ])
         .it('returns an error if key is not provided in headless mode',
             (ctx) => {
-                expect(ctx.stdout).to.contain('The key argument is required')
+                expect(ctx.stderr).to.contain('The key argument is required')
             }
         )
 

--- a/src/commands/targeting/get.test.ts
+++ b/src/commands/targeting/get.test.ts
@@ -189,10 +189,10 @@ describe('targeting get', () => {
             })
 
     dvcTest()
-        .stdout()
+        .stderr()
         .command(['targeting get', '--headless', ...authFlags])
         .it('does not prompt when using --headless',
             (ctx) => {
-                expect(ctx.stdout).to.contain('Feature argument is required')
+                expect(ctx.stderr).to.contain('Feature argument is required')
             })
 })

--- a/src/commands/targeting/update.test.ts
+++ b/src/commands/targeting/update.test.ts
@@ -222,7 +222,7 @@ describe('targeting update', () => {
         })
 
     dvcTest()
-        .stdout()
+        .stderr()
         .command([
             'targeting update',
             '--project', projectKey,
@@ -231,7 +231,7 @@ describe('targeting update', () => {
             '--targets', '[{ "name": "All Users", "serve": "variation-on", "definition": [{ "type": "all" }] }]'
         ])
         .it('fails to update a target in headless mode without feature key', (ctx) => {
-            expect(ctx.stdout).contains('Feature and environment arguments are required')
+            expect(ctx.stderr).contains('Feature and environment arguments are required')
         })
 
     let promptCount = 0

--- a/src/commands/variables/create.test.ts
+++ b/src/commands/variables/create.test.ts
@@ -71,7 +71,7 @@ describe('variables create', () => {
             })
 
     dvcTest()
-        .stdout()
+        .stderr()
         .command([
             'variables create',
             '--project', projectKey,
@@ -81,9 +81,8 @@ describe('variables create', () => {
             '--headless',
             ...authFlags
         ])
-        .it('Errors when called in headless mode with no key',
-            (ctx) => {
-                expect(ctx.stdout).to.contain('The key, name, feature, and type flags are required')
-            })
+        .it('Errors when called in headless mode with no key', (ctx) => {
+            expect(ctx.stderr).to.contain('The key, name, feature, and type flags are required')
+        })
 
 })

--- a/src/commands/variations/create.test.ts
+++ b/src/commands/variations/create.test.ts
@@ -191,15 +191,16 @@ describe('variations create', () => {
                 'new-variable': false
             }
         })
-        .stdout()
+        .stderr()
         .command([
             'variations create', featureKey,
             '--project', projectKey,
             '--headless',
             ...authFlags
         ])
+        .catch((err) => null)
         .it('errors when missing required flags in headless mode',
             (ctx) => {
-                expect(ctx.stdout).toMatchSnapshot()
+                expect(ctx.stderr).toMatchSnapshot()
             })
 })

--- a/src/commands/variations/list.test.ts
+++ b/src/commands/variations/list.test.ts
@@ -57,10 +57,9 @@ describe('variations list', () => {
             })
 
     dvcTest()
-        .stdout()
+        .stderr()
         .command(['variations list', '--headless', '--project', projectKey, ...authFlags])
-        .it('does not prompt when using --headless',
-            (ctx) => {
-                expect(ctx.stdout).to.contain('In headless mode, feature is required')
-            })
+        .it('does not prompt when using --headless', (ctx) => {
+            expect(ctx.stderr).to.contain('In headless mode, feature is required')
+        })
 })

--- a/src/ui/writer.ts
+++ b/src/ui/writer.ts
@@ -73,9 +73,9 @@ export default class Writer {
 
     public showError(message: string): void {
         if (this.headless) {
-            console.log(message)
+            console.error(message)
         } else {
-            console.log(chalk.red(`❌ ${message}`))
+            console.error(chalk.red(`❌ ${message}`))
         }
     }
 


### PR DESCRIPTION
Errors thrown by the CLI just being logged with a 0 exit code, so users of the CLI cannot properly handle errors.
Re-throw error after custom handling to be caught by the default oclif error handler as per their recommendation [in the docs](https://oclif.io/docs/error_handling/#error-handling-in-the-catch-method)