### PR TITLE
fix: Don't log error from oclif error handler

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -99,6 +99,7 @@ export default abstract class Base extends Command {
             } else {
                 this.writer.showError(error.message)
             }
+            Object.assign(error, { skipOclifErrorHandling: 1 })
             throw error
         }
     }


### PR DESCRIPTION
Don't re-log error from oclif error handler