### PR TITLE
fix: Return empty string when token refresh fails

### DIFF
--- a/src/auth/ApiAuth.ts
+++ b/src/auth/ApiAuth.ts
@@ -141,11 +141,12 @@ export class ApiAuth {
             storeAccessToken({ accessToken, refreshToken }, this.authPath)
             return accessToken
         } catch (e) {
-            let msg = 'Failed to refresh DevCycle API token. Please login using "dvc login again"'
+            let msg = 'Failed to refresh DevCycle API token.'
             if (e instanceof Error) {
                 msg += ` ${e.message}`
             }
-            throw new Error(msg)
+            console.log(msg)
+            return ''
         }
     }
 }


### PR DESCRIPTION
Currently an error will be thrown if token refresh fails, even if the command does not require auth. If token refresh fails, log the error message but return an empty string as the token — the default "auth required" message will be displayed if necessary