### PR TITLE
feat: Add pagination flags to variable list and get commands

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -46,10 +46,13 @@ DESCRIPTION
 ```
 USAGE
   $ dvc variables get [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
-    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--keys <value>]
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--keys <value>] [--page <value>]
+    [--per-page <value>]
 
 FLAGS
-  --keys=<value>  Comma-separated list of variable keys to fetch details for
+  --keys=<value>      Comma-separated list of variable keys to fetch details for
+  --page=<value>      Page number to fetch
+  --per-page=<value>  Number of variables to fetch per page
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file
@@ -68,7 +71,11 @@ GLOBAL FLAGS
 ```
 USAGE
   $ dvc variables list [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
-    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--page <value>] [--per-page <value>]
+
+FLAGS
+  --page=<value>      Page number to fetch
+  --per-page=<value>  Number of variables to fetch per page
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.4.2",
+  "version": "5.4.3",
   "commands": {
     "authCommand": {
       "id": "authCommand",
@@ -3728,6 +3728,18 @@
           "type": "option",
           "description": "Comma-separated list of variable keys to fetch details for",
           "multiple": false
+        },
+        "page": {
+          "name": "page",
+          "type": "option",
+          "description": "Page number to fetch",
+          "multiple": false
+        },
+        "per-page": {
+          "name": "per-page",
+          "type": "option",
+          "description": "Number of variables to fetch per page",
+          "multiple": false
         }
       },
       "args": {}
@@ -3812,6 +3824,18 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "page": {
+          "name": "page",
+          "type": "option",
+          "description": "Page number to fetch",
+          "multiple": false
+        },
+        "per-page": {
+          "name": "per-page",
+          "type": "option",
+          "description": "Number of variables to fetch per page",
+          "multiple": false
         }
       },
       "args": {}

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -51,18 +51,23 @@ export const updateVariable = async (
         })
 }
 
-export const fetchVariables = async (token: string, project_id: string, feature_id?: string) => {
+export const fetchVariables = async (
+    token: string,
+    project_id: string,
+    queries: {
+        feature?: string
+        page?: number
+        perPage?: number
+    } = {}
+) => {
     return await apiClient.get('/v1/projects/:project/variables', {
         headers: {
-            'Content-Type': 'application/json',
             Authorization: token,
         },
         params: {
             project: project_id,
         },
-        queries: {
-            ...(feature_id && { feature: feature_id })
-        }
+        queries
     })
 }
 
@@ -104,7 +109,6 @@ export const fetchVariableByKey = async (token: string, project_id: string, key:
     try {
         const response = await apiClient.get('/v1/projects/:project/variables/:key', {
             headers: {
-                'Content-Type': 'application/json',
                 Authorization: token,
             },
             params: {

--- a/src/commands/variables/get.test.ts
+++ b/src/commands/variables/get.test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@oclif/test'
+import { dvcTest } from '../../../test-utils'
+import { BASE_URL } from '../../api/common'
+
+describe('variables get', () => {
+    const projectKey = 'test-project'
+    const authFlags = ['--client-id', 'test-client-id', '--client-secret', 'test-client-secret']
+
+    const mockVariables = [
+        {
+            key: 'variable-1',
+            name: 'Variable 1',
+            _id: '61450f3daec96f5cf4a49946'
+        },
+        {
+            key: 'variable-2',
+            name: 'Variable 2',
+            _id: '61450f3daec96f5cf4a49947',
+        }
+    ]
+
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/variables`)
+            .reply(200, mockVariables)
+        )
+        .stdout()
+        .command(['variables get', '--project', projectKey, ...authFlags])
+        .it('returns a list of variable objects',
+            (ctx) => {
+                expect(ctx.stdout).to.contain(JSON.stringify(mockVariables, null, 2))
+            })
+
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/variables`)
+            .query({ page: 2, perPage: 10 })
+            .reply(200, mockVariables)
+        )
+        .stdout()
+        .command([
+            'variables get',
+            '--project', projectKey,
+            '--page', '2',
+            '--per-page', '10',
+            ...authFlags
+        ])
+        .it('passes pagination params to api',
+            (ctx) => {
+                expect(ctx.stdout).to.contain(JSON.stringify(mockVariables, null, 2))
+            })
+})

--- a/src/commands/variables/get.ts
+++ b/src/commands/variables/get.ts
@@ -10,6 +10,12 @@ export default class DetailedVariables extends Base {
         'keys': Flags.string({
             description: 'Comma-separated list of variable keys to fetch details for',
         }),
+        'page': Flags.integer({
+            description: 'Page number to fetch'
+        }),
+        'per-page': Flags.integer({
+            description: 'Number of variables to fetch per page'
+        })
     }
     authRequired = true
 
@@ -27,7 +33,11 @@ export default class DetailedVariables extends Base {
             )
 
         } else {
-            variables = await fetchVariables(this.authToken, this.projectKey)
+            const query = {
+                page: flags['page'],
+                perPage: flags['per-page'],
+            }
+            variables = await fetchVariables(this.authToken, this.projectKey, query)
         }
         this.writer.showResults(variables)
     }

--- a/src/commands/variables/list.test.ts
+++ b/src/commands/variables/list.test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@oclif/test'
+import { dvcTest } from '../../../test-utils'
+import { BASE_URL } from '../../api/common'
+
+describe('variables list', () => {
+    const projectKey = 'test-project'
+    const authFlags = ['--client-id', 'test-client-id', '--client-secret', 'test-client-secret']
+
+    const mockVariables = [
+        {
+            key: 'variable-1',
+            name: 'Variable 1',
+            _id: '61450f3daec96f5cf4a49946'
+        },
+        {
+            key: 'variable-2',
+            name: 'Variable 2',
+            _id: '61450f3daec96f5cf4a49947',
+        }
+    ]
+
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/variables`)
+            .reply(200, mockVariables)
+        )
+        .stdout()
+        .command(['variables list', '--project', projectKey, ...authFlags])
+        .it('returns a list of variable keys',
+            (ctx) => {
+                expect(ctx.stdout).to.contain(JSON.stringify(['variable-1', 'variable-2'], null, 2))
+            })
+
+    dvcTest()
+        .nock(BASE_URL, (api) => api
+            .get(`/v1/projects/${projectKey}/variables`)
+            .query({ page: 2, perPage: 10 })
+            .reply(200, mockVariables)
+        )
+        .stdout()
+        .command([
+            'variables list',
+            '--project', projectKey,
+            '--page', '2',
+            '--per-page', '10',
+            ...authFlags
+        ])
+        .it('passes pagination params to api',
+            (ctx) => {
+                expect(ctx.stdout).to.contain(JSON.stringify(['variable-1', 'variable-2'], null, 2))
+            })
+})

--- a/src/commands/variables/list.ts
+++ b/src/commands/variables/list.ts
@@ -1,14 +1,30 @@
+import { Flags } from '@oclif/core'
 import { fetchVariables } from '../../api/variables'
 import Base from '../base'
 
 export default class ListVariables extends Base {
     static hidden = false
+    static flags = {
+        ...Base.flags,
+        'page': Flags.integer({
+            description: 'Page number to fetch'
+        }),
+        'per-page': Flags.integer({
+            description: 'Number of variables to fetch per page'
+        })
+    }
     authRequired = true
+
     public async run(): Promise<void> {
         const { flags } = await this.parse(ListVariables)
         const { headless, project } = flags
         await this.requireProject(project, headless)
-        const variables = await fetchVariables(this.authToken, this.projectKey)
+
+        const query = {
+            page: flags['page'],
+            perPage: flags['per-page'],
+        }
+        const variables = await fetchVariables(this.authToken, this.projectKey, query)
         const variableKeys = variables.map((variable) => variable.key)
         this.writer.showResults(variableKeys)
     }

--- a/src/commands/variations/create.ts
+++ b/src/commands/variations/create.ts
@@ -74,7 +74,7 @@ export default class CreateVariation extends CreateCommand {
                 }
                 feature_id = feature._id
             }
-            const variablesForFeature = await fetchVariables(this.authToken, this.projectKey, feature_id)
+            const variablesForFeature = await fetchVariables(this.authToken, this.projectKey, { feature: feature_id })
             variableAnswers = await promptForVariationVariableValues(
                 variablesForFeature
             )

--- a/src/ui/prompts/variablePrompts.ts
+++ b/src/ui/prompts/variablePrompts.ts
@@ -19,7 +19,7 @@ let choices: { name: string, value: Variable }[]
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const variableChoices = async (input: Record<string, any>, search: string): Promise<VariableChoice[]> => {
     if (!choices) {
-        const variables = await fetchVariables(input.token, input.projectKey)
+        const variables = await fetchVariables(input.token, input.projectKey, { perPage: 1000 })
         choices = variables.map((variable) => {
             const name = variable.name ? `${variable.name} ${chalk.dim(`(${variable.key})`)}` : variable.key
             return {

--- a/src/ui/prompts/variationPrompts.ts
+++ b/src/ui/prompts/variationPrompts.ts
@@ -31,7 +31,7 @@ export const variationChoices = async (input: Record<string, any>):Promise<Varia
 }
 
 export const featureVariableChoices = async (authToken: string, projectKey: string, featureKey: string) => {
-    const variablesMap = await fetchVariables(authToken, projectKey, featureKey)
+    const variablesMap = await fetchVariables(authToken, projectKey, { feature: featureKey })
     const choices = []
     for (const variable of variablesMap) {
         const displayVariableType = chalk.dim(`(${variable.type})`)


### PR DESCRIPTION
Add `page` and `per-page` flags to variables `list` and `get` commands. This will support fetching all variables from the vscode extension