### PR TITLE
fix: Use writer to log from ApiAuth

### DIFF
--- a/src/auth/ApiAuth.ts
+++ b/src/auth/ApiAuth.ts
@@ -9,6 +9,7 @@ import { AUTH_URL } from '../api/common'
 import { TokenCache } from './TokenCache'
 import { getOrgIdFromToken, getTokenExpiry, shouldRefreshToken } from './utils'
 import { CLI_CLIENT_ID } from './SSOAuth'
+import Writer from '../ui/writer'
 
 type SupportedFlags = {
     'client-id'?: string
@@ -16,11 +17,13 @@ type SupportedFlags = {
 }
 
 export class ApiAuth {
-    private authPath: string
     private tokenCache: TokenCache
 
-    constructor(authPath: string, cacheDir: string) {
-        this.authPath = authPath
+    constructor(
+        private authPath: string,
+        cacheDir: string,
+        private writer: Writer
+    ) {
         this.tokenCache = new TokenCache(cacheDir)
     }
 
@@ -145,7 +148,7 @@ export class ApiAuth {
             if (e instanceof Error) {
                 msg += ` ${e.message}`
             }
-            console.log(msg)
+            this.writer.warningMessage(msg)
             return ''
         }
     }

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -105,7 +105,7 @@ export default abstract class Base extends Command {
     }
     private async authorizeApi(): Promise<void> {
         const { flags } = await this.parse(this.constructor as typeof Base)
-        const auth = new ApiAuth(this.authPath, this.config.cacheDir)
+        const auth = new ApiAuth(this.authPath, this.config.cacheDir, this.writer)
         this.authToken = await auth.getToken(flags, this.orgId)
         this.personalAccessToken = auth.getPersonalToken()
 


### PR DESCRIPTION
Use Writer to log from ApiAuth to only show log when not running in headless mode. Currently the log is printed in headless mode which breaks the json parsing of the output