### PR TITLE
feat: add dvc identity get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ USAGE
 * [`dvc features`](docs/features.md) - Create, view, or modify Features with the Management API.
 * [`dvc generate`](docs/generate.md) - Generate Devcycle related files.
 * [`dvc help`](docs/help.md) - Display help for dvc.
-* [`dvc identity`](docs/identity.md) - Update your DevCycle Identity.
+* [`dvc identity`](docs/identity.md) - View or update your DevCycle Identity.
 * [`dvc keys`](docs/keys.md) - Retrieve SDK keys from the Management API.
 * [`dvc login`](docs/login.md) - Log in to DevCycle.
 * [`dvc logout`](docs/logout.md) - Discards any auth configuration that has been stored in the auth configuration file.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ USAGE
 * [`dvc features`](docs/features.md) - Create, view, or modify Features with the Management API.
 * [`dvc generate`](docs/generate.md) - Generate Devcycle related files.
 * [`dvc help`](docs/help.md) - Display help for dvc.
-* [`dvc identity`](docs/identity.md) - View or update your DevCycle Identity.
+* [`dvc identity`](docs/identity.md) - View or manage your DevCycle Identity.
 * [`dvc keys`](docs/keys.md) - Retrieve SDK keys from the Management API.
 * [`dvc login`](docs/login.md) - Log in to DevCycle.
 * [`dvc logout`](docs/logout.md) - Discards any auth configuration that has been stored in the auth configuration file.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,9 +1,34 @@
 `dvc identity`
 ==============
 
-Update your DevCycle Identity.
+View or update your DevCycle Identity.
 
+* [`dvc identity get`](#dvc-identity-get)
 * [`dvc identity update`](#dvc-identity-update)
+
+## `dvc identity get`
+
+Print your DevCycle Identity.
+
+```
+USAGE
+  $ dvc identity get [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless]
+
+GLOBAL FLAGS
+  --auth-path=<value>         Override the default location to look for an auth.yml file
+  --client-id=<value>         Client ID to use for DevCycle API Authorization
+  --client-secret=<value>     Client Secret to use for DevCycle API Authorization
+  --config-path=<value>       Override the default location to look for the user.yml file
+  --headless                  Disable all interactive flows and format output for easy parsing.
+  --no-api                    Disable API-based enhancements for commands where authorization is optional. Suppresses
+                              warnings about missing credentials.
+  --project=<value>           Project key to use for the DevCycle API requests
+  --repo-config-path=<value>  Override the default location to look for the repo config.yml file
+
+DESCRIPTION
+  Print your DevCycle Identity.
+```
 
 ## `dvc identity update`
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,7 +1,7 @@
 `dvc identity`
 ==============
 
-View or update your DevCycle Identity.
+View or manage your DevCycle Identity.
 
 * [`dvc identity get`](#dvc-identity-get)
 * [`dvc identity update`](#dvc-identity-update)

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1917,6 +1917,91 @@
       },
       "args": {}
     },
+    "identity:get": {
+      "id": "identity:get",
+      "description": "Print your DevCycle Identity.",
+      "strict": true,
+      "pluginName": "@devcycle/cli",
+      "pluginAlias": "@devcycle/cli",
+      "pluginType": "core",
+      "hidden": false,
+      "aliases": [],
+      "flags": {
+        "config-path": {
+          "name": "config-path",
+          "type": "option",
+          "description": "Override the default location to look for the user.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "auth-path": {
+          "name": "auth-path",
+          "type": "option",
+          "description": "Override the default location to look for an auth.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "repo-config-path": {
+          "name": "repo-config-path",
+          "type": "option",
+          "description": "Override the default location to look for the repo config.yml file",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-id": {
+          "name": "client-id",
+          "type": "option",
+          "description": "Client ID to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "client-secret": {
+          "name": "client-secret",
+          "type": "option",
+          "description": "Client Secret to use for DevCycle API Authorization",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "project": {
+          "name": "project",
+          "type": "option",
+          "description": "Project key to use for the DevCycle API requests",
+          "helpGroup": "Global",
+          "multiple": false
+        },
+        "no-api": {
+          "name": "no-api",
+          "type": "boolean",
+          "description": "Disable API-based enhancements for commands where authorization is optional. Suppresses warnings about missing credentials.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "headless": {
+          "name": "headless",
+          "type": "boolean",
+          "description": "Disable all interactive flows and format output for easy parsing.",
+          "helpGroup": "Global",
+          "allowNo": false
+        },
+        "caller": {
+          "name": "caller",
+          "type": "option",
+          "description": "The integration that is calling the CLI.",
+          "hidden": true,
+          "helpGroup": "Global",
+          "multiple": false,
+          "options": [
+            "github.pr_insights",
+            "github.code_usages",
+            "bitbucket.pr_insights",
+            "bitbucket.code_usages",
+            "cli",
+            "vscode_extension"
+          ]
+        }
+      },
+      "args": {}
+    },
     "identity:update": {
       "id": "identity:update",
       "description": "Update your DevCycle Identity.",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "description": "Generate Devcycle related files."
       },
       "identity": {
-        "description": "View or update your DevCycle Identity."
+        "description": "View or manage your DevCycle Identity."
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,9 @@
       },
       "generate": {
         "description": "Generate Devcycle related files."
+      },
+      "identity": {
+        "description": "View or update your DevCycle Identity."
       }
     }
   },

--- a/src/commands/identity/get.ts
+++ b/src/commands/identity/get.ts
@@ -12,7 +12,17 @@ export default class DetailedIdentity extends Base {
         await this.requireProject(project, headless)
 
         const identity = await fetchUserProfile(this.authToken, this.projectKey)
-        this.writer.infoMessage(`DevCycle Identity for Project: ${this.projectKey}`)
-        this.writer.showResults(identity)
+        const dvcUserId = identity.dvcUserId ?? '<not set>'
+
+        this.writer.showRawResults(`Current DevCycle Project: ${this.projectKey}`)
+        this.writer.showRawResults(`SDK Associated User ID: ${dvcUserId}`)
+        if (this.hasToken()) {
+            const tokenJson = JSON.parse(Buffer.from(this.authToken.split('.')[1], 'base64').toString())
+            const email = tokenJson['https://devcycle.com/email']
+            this.writer.showRawResults(`Email: ${email}`)
+        }
+        if (!identity.dvcUserId) {
+            this.writer.infoMessageWithCommand('To set up your SDK Associated User ID, use', 'dvc identity update')
+        }
     }
 }

--- a/src/commands/identity/get.ts
+++ b/src/commands/identity/get.ts
@@ -1,0 +1,18 @@
+import Base from '../base'
+import { fetchUserProfile } from '../../api/userProfile'
+
+export default class DetailedIdentity extends Base {
+    static hidden = false
+    authRequired = true
+    static description = 'Print your DevCycle Identity.'
+
+    public async run(): Promise<void> {
+        const { flags } = await this.parse(DetailedIdentity)
+        const { project, headless } = flags
+        await this.requireProject(project, headless)
+
+        const identity = await fetchUserProfile(this.authToken, this.projectKey)
+        this.writer.infoMessage(`DevCycle Identity for Project: ${this.projectKey}`)
+        this.writer.showResults(identity)
+    }
+}

--- a/src/ui/writer.ts
+++ b/src/ui/writer.ts
@@ -22,6 +22,10 @@ export default class Writer {
         if (!this.headless) console.log((`🤖 ${message}`))
     }
 
+    public infoMessageWithCommand(message: string, command: string): void {
+        if (!this.headless) console.log((`🤖 ${message} ${chalk.bold(command)}`))
+    }
+
     public title(message: string): void {
         if (!this.headless) console.log((`🤖 ${chalk.bold(message)}`))
     }


### PR DESCRIPTION
- added `dvc identity get` command
- can take project key as well, otherwise gets identity for current project
![cli-identity-get](https://github.com/DevCycleHQ/cli/assets/98763537/b1fd1e9a-a641-450c-bf03-21c39f7587d6)
    - chantal's project has a dvcUserId set, chantal 2.0 does not 