### PR TITLE
feat: add dvc overrides clear for feature and environment

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -7,15 +7,18 @@ Create, view, or modify Overrides for a Project with the Management API.
 
 ## `dvc overrides clear`
 
-Clear Overrides for a given Project.
+Clear Overrides for a given Feature or Project.
 
 ```
 USAGE
   $ dvc overrides clear [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
-    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--all]
+    <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--all] [--feature <value>]
+    [--environment <value>]
 
 FLAGS
-  --all  All Overrides for the Project
+  --all                  All Overrides for the Project
+  --environment=<value>  The key or id of the Environment to clear the Override for
+  --feature=<value>      The key or id of the Feature to clear the Override for
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file
@@ -29,5 +32,5 @@ GLOBAL FLAGS
   --repo-config-path=<value>  Override the default location to look for the repo config.yml file
 
 DESCRIPTION
-  Clear Overrides for a given Project.
+  Clear Overrides for a given Feature or Project.
 ```

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -2734,7 +2734,7 @@
     },
     "overrides:clear": {
       "id": "overrides:clear",
-      "description": "Clear Overrides for a given Project.",
+      "description": "Clear Overrides for a given Feature or Project.",
       "strict": true,
       "pluginName": "@devcycle/cli",
       "pluginAlias": "@devcycle/cli",
@@ -2819,6 +2819,18 @@
           "type": "boolean",
           "description": "All Overrides for the Project",
           "allowNo": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "option",
+          "description": "The key or id of the Feature to clear the Override for",
+          "multiple": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "option",
+          "description": "The key or id of the Environment to clear the Override for",
+          "multiple": false
         }
       },
       "args": {}

--- a/src/api/overrides.ts
+++ b/src/api/overrides.ts
@@ -1,17 +1,36 @@
 import apiClient from './apiClient'
 import { buildHeaders } from './common'
 
-const BASE_URL = '/v1/projects/:project/overrides/current'
+const BASE_URL = '/v1/projects/:project'
 
 export const deleteAllProjectOverrides = async (
     token: string,
     project_id: string,
 ) => {
-    return apiClient.delete(`${BASE_URL}`, undefined,
+    return apiClient.delete(`${BASE_URL}/overrides/current`, undefined,
         {
             headers: buildHeaders(token),
             params: {
                 project: project_id,
+            },
+        })
+}
+
+export const deleteFeatureOverrides = async (
+    token: string,
+    project_id: string,
+    feature: string,
+    environment: string
+) => {
+    return apiClient.delete(`${BASE_URL}/features/:feature/overrides/current`, undefined,
+        {
+            headers: buildHeaders(token),
+            params: {
+                project: project_id,
+                feature: feature,
+            },
+            queries: {
+                environment: environment,
             },
         })
 }

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -3334,6 +3334,44 @@ const endpoints = makeApi([
             },
         ],
     },
+    {
+        method: 'delete',
+        path: '/v1/projects/:project/features/:feature/overrides/current',
+        alias: 'OverridesController_deleteFeatureOverrides',
+        requestFormat: 'json',
+        parameters: [
+            {
+                name: 'project',
+                type: 'Path',
+                schema: z.string(),
+            },
+            {
+                name: 'feature',
+                type: 'Path',
+                schema: z.string(),
+            },
+            {
+                name: 'environment',
+                type: 'Query',
+                schema: z.string(),
+            },
+        ],
+        response: z.void(),
+        errors: [
+            {
+                status: 400,
+                schema: BadRequestErrorResponse,
+            },
+            {
+                status: 401,
+                schema: z.void(),
+            },
+            {
+                status: 404,
+                schema: NotFoundErrorResponse,
+            },
+        ],
+    },
 ])
 
 export const api = new Zodios(endpoints)

--- a/src/commands/overrides/clear.ts
+++ b/src/commands/overrides/clear.ts
@@ -1,13 +1,14 @@
 import inquirer from 'inquirer'
 
 import { Flags } from '@oclif/core'
-import { deleteAllProjectOverrides } from '../../api/overrides'
+import { deleteAllProjectOverrides, deleteFeatureOverrides } from '../../api/overrides'
 import Base from '../base'
+import { FeaturePromptResult, featurePrompt, EnvironmentPromptResult, environmentPrompt } from '../../ui/prompts'
 
 export default class DeleteOverrides extends Base {
     static hidden = false
     authRequired = true
-    static description = 'Clear Overrides for a given Project.'
+    static description = 'Clear Overrides for a given Feature or Project.'
 
     prompts = []
 
@@ -19,35 +20,79 @@ export default class DeleteOverrides extends Base {
             description: 'All Overrides for the Project',
             allowNo: false,
         }),
+        feature: Flags.string({
+            name: 'feature',
+            description: 'The key or id of the Feature to clear the Override for',
+        }),
+        environment: Flags.string({
+            name: 'environment',
+            description: 'The key or id of the Environment to clear the Override for',
+        }),
         ...Base.flags,
     }
 
     public async run(): Promise<void> {
 
         const { flags } = await this.parse(DeleteOverrides)
-        const { headless, project } = flags
+        const { headless, project, all, feature, environment } = flags
 
-        if (!flags.all) {
-            this.writer.showError('The \'--all\' flag is required to proceed.')
-            return
-        }
         await this.requireProject(project, headless)
 
-        if (!headless) {
-            const { confirmClear } = await inquirer.prompt([{
-                name: 'confirmClear',
-                message: `Are you sure you want to clear ALL Overrides for project: ${this.projectKey}?`,
-                type: 'confirm'
-            }])
-            if (!confirmClear) {
-                this.writer.warningMessage(`No Overrides cleared for project: ${this.projectKey}`)
-                return
+        if (all) {
+            if (!headless) {
+                const { confirmClear } = await inquirer.prompt([{
+                    name: 'confirmClear',
+                    message: `Are you sure you want to clear ALL Overrides for project: ${this.projectKey}?`,
+                    type: 'confirm'
+                }])
+                if (!confirmClear) {
+                    this.writer.warningMessage(`No Overrides cleared for project: ${this.projectKey}`)
+                    return
+                }
             }
+
+            await deleteAllProjectOverrides(this.authToken, this.projectKey)
+            this.writer.successMessage(
+                `Successfully cleared all overrides for project: ${this.projectKey}`
+            )
+            return
         }
 
-        await deleteAllProjectOverrides(this.authToken, this.projectKey)
+        let featureKey = feature
+        if (!feature && !headless) {
+            const featurePromptResult = await inquirer.prompt<FeaturePromptResult>([featurePrompt], {
+                token: this.authToken,
+                projectKey: this.projectKey
+            })
+            featureKey = featurePromptResult.feature.key
+        }
+
+        let environmentKey = environment
+        if (!environment && !headless) {
+            const { environment: environmentPromptResult } = await inquirer.prompt<EnvironmentPromptResult>(
+                [environmentPrompt], {
+                    token: this.authToken,
+                    projectKey: this.projectKey
+                })
+            environmentKey = environmentPromptResult._id
+        }
+
+        if (!featureKey || !environmentKey) {
+            this.writer.showError(
+                'Both the \'--feature\' and \'--environment\' flags or the \'--all\' flag must be provided to proceed.'
+            )
+            return
+        }
+                
+        await deleteFeatureOverrides(
+            this.authToken,
+            this.projectKey,
+            featureKey,
+            environmentKey
+        )
         this.writer.successMessage(
-            `Successfully cleared all overrides for project: ${this.projectKey}`
+            `Successfully cleared all overrides for the Feature '${featureKey}'`
+                    + ` and Environment '${environmentKey}'`
         )
     }
 }


### PR DESCRIPTION
- added command `dvc overrides clear --feature <feature> --environment <environment>`
- works in headless mode
- `--all` flag takes precedence if specified along with `--feature` and `--environment`

non-headless:
![cli-overrides-clear](https://github.com/DevCycleHQ/cli/assets/98763537/f073b938-acc3-43a4-8615-d58d3254c480)

headless:
![cli-overrides-clear-headless-2](https://github.com/DevCycleHQ/cli/assets/98763537/75d6fec0-9df5-4fce-af1f-efc130afa2e3)
