### PR TITLE
feat: Update output message when no variables changed in diff

### DIFF
--- a/src/commands/diff/__snapshots__/diff.test.ts.snap
+++ b/src/commands/diff/__snapshots__/diff.test.ts.snap
@@ -160,6 +160,13 @@ DevCycle Variable Changes:
 "
 `;
 
+exports[`diff returns "No DevCycle Variables Changed" when there are no changes 1`] = `
+"
+No DevCycle Variables Changed
+
+"
+`;
+
 exports[`diff runs against a test file 1`] = `
 "
 DevCycle Variable Changes:

--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -192,4 +192,14 @@ describe('diff', () => {
                 expect(ctx.stdout).to.contain('Pattern for javascript parser')
 
             })
+
+    test
+        .stdout()
+        .command(['diff', '--file',
+            'test-utils/fixtures/diff/no-change', '--no-api'
+        ])
+        .it('returns "No DevCycle Variables Changed" when there are no changes',
+            (ctx) => {
+                expect(ctx.stdout).toMatchSnapshot()
+            })
 })

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -236,6 +236,12 @@ export default class Diff extends Base {
             )
             headerIcon = `${buildIcon(lightTogglebot)}${buildIcon(darkTogglebot)} `
         }
+
+        const totalChanges = totalAdditions + totalDeletions + totalNotices + totalCleanup
+        if (totalChanges === 0) {
+            this.log(`\n${subHeaderPrefix}${headerIcon}No DevCycle Variables Changed\n`)
+            return
+        }
         this.log(`\n${headerPrefix}${headerIcon}${headerText}`)
 
         if (totalNotices) {


### PR DESCRIPTION
Update `dvc diff` command to output "No DevCycle Variables Changed" when no changes are found in diff. This will be used by the github actions to determine if a comment should be added to a PR