### PR TITLE
chore: overrides update command to print results in table

### DIFF
--- a/src/commands/overrides/list.ts
+++ b/src/commands/overrides/list.ts
@@ -2,7 +2,6 @@ import { ux } from '@oclif/core'
 import Base from '../base'
 import { fetchProjectOverridesForUser } from '../../api/overrides'
 import { UserOverride } from '../../api/schemas'
-import { over } from 'lodash'
 
 export default class DetailedOverrides extends Base {
     static hidden = false


### PR DESCRIPTION
- updated the `overrides update` command to print the results in a table
<img width="844" alt="image" src="https://github.com/DevCycleHQ/cli/assets/98763537/c8ad701f-5948-4f12-a382-68414892486a">
