### PR TITLE
chore: add repository dispatch step when publishing cli for homebrew tap

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -88,3 +88,12 @@ jobs:
         with:
           latest_tag: $LATEST_TAG
           access_token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+      
+      # Move this to release action yml once it works the first time
+      - name: Update Homebrew Formula
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          repository: DevCycleHQ/homebrew-cli
+          event-type: start-deploy
+        


### PR DESCRIPTION
# Changes

- Added step to trigger `homebrew-cli`  workflow after publishing to npm