### PR TITLE
Only update selected variation values instead of overriding all

### DIFF
--- a/src/commands/variations/update.test.ts
+++ b/src/commands/variations/update.test.ts
@@ -12,7 +12,7 @@ describe('variations update', () => {
     const authFlags = ['--client-id', 'test-client-id', '--client-secret', 'test-client-secret']
     const featureKey = 'spam'
     const variationKey = 'variation'
-    const requestVariables = { 'first-feature': true }
+    const requestVariables = { 'first-feature': true, 'new-variable': false }
 
     const requestBody = {
         'name': 'Test Variation',

--- a/src/commands/variations/update.ts
+++ b/src/commands/variations/update.ts
@@ -103,7 +103,7 @@ export default class UpdateVariation extends UpdateCommandWithCommonProperties {
             {
                 key: data.key,
                 name: data.name,
-                variables: variables ? JSON.parse(variables) : variableAnswers
+                variables: variables ? JSON.parse(variables) : { ...selectedVariation.variables, ...variableAnswers }
             }
         )
         this.writer.showResults(result)


### PR DESCRIPTION
Previously if you update variation values and only select some of the variables, the other variable values would be deleted. 