### PR TITLE
fix: Update repo init command to not open browser window unless it needs to

### DIFF
--- a/docs/login.md
+++ b/docs/login.md
@@ -16,7 +16,7 @@ USAGE
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--org <value>]
 
 FLAGS
-  --org=<value>  The `name` of the org to sign in as (not the `display_name`)
+  --org=<value>  The name or ID of the org to sign into
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file
@@ -46,7 +46,7 @@ USAGE
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--org <value>]
 
 FLAGS
-  --org=<value>  The `name` of the org to sign in as (not the `display_name`)
+  --org=<value>  The name or ID of the org to sign into
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -65,7 +65,7 @@ USAGE
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--org <value>]
 
 FLAGS
-  --org=<value>  The `name` of the org to sign in as (not the `display_name`)
+  --org=<value>  The name or ID of the org to sign into
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -96,7 +96,7 @@ USAGE
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--org <value>]
 
 FLAGS
-  --org=<value>  The `name` of the org to sign in as (not the `display_name`)
+  --org=<value>  The name or ID of the org to sign into
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/docs/repo.md
+++ b/docs/repo.md
@@ -15,7 +15,7 @@ USAGE
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--org <value>]
 
 FLAGS
-  --org=<value>  The `name` of the org to sign in as (not the `display_name`)
+  --org=<value>  The name or ID of the org to sign into
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/src/commands/repo/init.ts
+++ b/src/commands/repo/init.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata'
 
-import SSOAuth from '../../auth/SSOAuth'
 import AuthCommand from '../authCommand'
 
 export default class InitRepo extends AuthCommand {
     static hidden = false
     static description = 'Create the repo configuration file. This will open a browser window.'
     static examples = []
+    userAuthRequired = true
 
     public async run(): Promise<void> {
         if (this.repoConfig) {
@@ -14,10 +14,6 @@ export default class InitRepo extends AuthCommand {
         }
 
         this.repoConfig = await this.updateRepoConfig({})
-
-        const ssoAuth = new SSOAuth(this.writer, this.authPath)
-        const tokens = await ssoAuth.getAccessToken()
-        this.authToken = tokens.accessToken
 
         await this.setOrganizationAndProject()
     }


### PR DESCRIPTION
Currently when calling `repo init` it will always open two browser windows. Avoid running the full sso auth flow if we already have a valid token for the selected org