### PR TITLE
feat: Add handling for gitlab pr links

### DIFF
--- a/src/commands/diff/__snapshots__/diff.test.ts.snap
+++ b/src/commands/diff/__snapshots__/diff.test.ts.snap
@@ -260,6 +260,37 @@ DevCycle Variable Changes:
 "
 `;
 
+exports[`diff runs against a test file and linkifies the output for a gitlab MR 1`] = `
+"
+DevCycle Variable Changes:
+
+🟢  6 Variables Added
+🔴  1 Variable Removed
+
+🟢 Added
+
+  1. simple-case
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L1](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+  2. duplicate-case
+	   Locations:
+	    - [test-utils/fixtures/diff/sampleDiff.js:L2](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+	    - [test-utils/fixtures/diff/sampleDiff.js:L3](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+  3. single-quotes
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L5](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+  4. multi-line
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L11](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+  5. multi-line-comment
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L21](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+  6. duplicate-same-line
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L26](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+
+🔴 Removed
+
+  1. simple-case
+	   Location: [test-utils/fixtures/diff/sampleDiff.js:L1](https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6/diffs#diff-content-934428700c2f83423b2b273991070db8c347f8af)
+"
+`;
+
 exports[`diff runs against a test file with a custom matcher 1`] = `
 "
 DevCycle Variable Changes:

--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -97,6 +97,16 @@ describe('diff', () => {
         })
 
     test
+        .stdout()
+        .command([
+            'diff', '--file', './test-utils/fixtures/diff/e2e', '--no-api',
+            '--pr-link', 'https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/merge_requests/6'
+        ])
+        .it('runs against a test file and linkifies the output for a gitlab MR', (ctx) => {
+            expect(ctx.stdout).toMatchSnapshot()
+        })
+
+    test
         .nock(AUTH_URL, (api) => {
             api.post('/oauth/token', {
                 grant_type: 'client_credentials',


### PR DESCRIPTION
Handle PR links for gitlab in the response from the `dvc diff` command

Currently this only links to the relevant file. I'm not sure we can reliably link to the changed line