### PR TITLE
fix: Set personalAccessToken to be used by sso command

### DIFF
--- a/src/commands/login/sso.ts
+++ b/src/commands/login/sso.ts
@@ -12,6 +12,7 @@ export default class LoginSSO extends AuthCommand {
         const ssoAuth = new SSOAuth(this.writer, this.authPath)
         const tokens = await ssoAuth.getAccessToken()
         this.authToken = tokens.accessToken
+        this.personalAccessToken = tokens.personalAccessToken
         await this.setOrganizationAndProject()
     }
 }


### PR DESCRIPTION
The command `dvc login sso` fetches a personal access token and then uses it to fetch the available organizations. This was failing on the first attempt because the access token is written to the auth file but not made available to the current command