### PR TITLE
fix: Don't include variations in feature update if they were not modified

### DIFF
--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -51,6 +51,10 @@ describe('features update', () => {
         key: 'new-feature-key',
         description: 'test description',
         sdkVisibility: testSDKVisibility,
+    }
+
+    const requestBodyWithVariations = {
+        ...requestBody,
         variations: [],
     }
 
@@ -109,9 +113,9 @@ describe('features update', () => {
     // interactive mode:
     dvcTest()
         .stub(inquirer, 'prompt', () => ({
-            ...requestBody,
+            ...requestBodyWithVariations,
             sdkVisibility: ['mobile', 'server'],
-            whichFields: Object.keys(requestBody),
+            whichFields: Object.keys(requestBodyWithVariations),
             listPromptOption: 'continue',
         }))
         .nock(BASE_URL, (api) => api
@@ -119,7 +123,7 @@ describe('features update', () => {
             .reply(200, mockFeature)
         )
         .nock(BASE_URL, (api) => api
-            .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBody)
+            .patch(`/v1/projects/${projectKey}/features/${mockFeature.key}`, requestBodyWithVariations)
             .reply(200, mockFeature)
         )
         .stdout()

--- a/src/commands/features/update.ts
+++ b/src/commands/features/update.ts
@@ -92,10 +92,6 @@ export default class UpdateFeature extends UpdateCommandWithCommonProperties {
             ...(sdkVisibility ? { sdkVisibility: JSON.parse(sdkVisibility) } : {}),
             headless,
         })
-        // if variations were set by the variations list option or flag, 
-        // they should override the variations set by the variables list option
-        params.variations = params.variations || variableListOptions.featureVariations
-
         const result = await updateFeature(this.authToken, this.projectKey, feature.key, params)
         this.writer.showResults(result)
     }

--- a/src/ui/prompts/commonPrompts.ts
+++ b/src/ui/prompts/commonPrompts.ts
@@ -86,6 +86,9 @@ export const handleCustomPrompts = async (prompts: Prompt[], authToken: string, 
         const carryForward: Record<string, any> = {}
         prompt.previousReponseFields?.forEach((field) => carryForward[field] = result[field])
         result[prompt.name] = await prompt.listOptionsPrompt(carryForward)
+        if (prompt.checkForAdditionalProperties) {
+            Object.assign(result, prompt.checkForAdditionalProperties())
+        }
     }
 
     return transformResponse(result, prompts)

--- a/src/ui/prompts/listPrompts/listOptionsPrompt.ts
+++ b/src/ui/prompts/listPrompts/listOptionsPrompt.ts
@@ -17,6 +17,8 @@ export abstract class ListOptionsPrompt<T> {
     abstract itemType: string
     writer: Writer
     list: ListOption<T>[]
+    additionalProperties = []
+
     constructor(list: T[], writer: Writer) {
         this.list = this.transformToListOptions(list)
         this.writer = writer

--- a/src/ui/prompts/listPrompts/variablesListPrompt.ts
+++ b/src/ui/prompts/listPrompts/variablesListPrompt.ts
@@ -17,6 +17,7 @@ export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams>
 
     variablePropertyPrompts = createVariablePrompts.filter((prompt) => prompt.name !== '_feature')
     featureVariations: Variation[]
+    variationsModified = false
 
     constructor(list: Variable[], writer: Writer, variations?: Variation[]) {
         super(list, writer)
@@ -30,7 +31,10 @@ export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams>
         value: 'variables', 
         message: 'Manage variables',
         type: 'listOptions',
-        listOptionsPrompt: () => this.prompt()
+        listOptionsPrompt: () => this.prompt(),
+        checkForAdditionalProperties: () => (
+            this.variationsModified ? { 'variations': this.featureVariations } : {}
+        )
     })
 
     private async promptVariationValues(variable: Variable) {
@@ -46,6 +50,7 @@ export class VariableListOptions extends ListOptionsPrompt<CreateVariableParams>
                 variation.variables = variation.variables || {}
                 variation.variables[variable.key] = result[variation.key]
             }
+            this.variationsModified = true
         }
     }
 

--- a/src/ui/prompts/types.ts
+++ b/src/ui/prompts/types.ts
@@ -24,6 +24,8 @@ export type ListPrompt = Prompt & {
   type: 'listOptions',
   listOptionsPrompt: (previousResponses?: Record<string, any>) => Promise<any>
   previousReponseFields?: string[]
+  // Checks if prompt modified other properties. Returns a map of property names to values
+  checkForAdditionalProperties?: () => Record<string, any>
 }
 
 export type AutoCompletePrompt = Prompt & {


### PR DESCRIPTION
Currently variations are always submitted with the feature update request. This causes a 412 error if the variations include a variable that was removed by the current command. Variations should not be included in the request unless they are modified.

Add an optional `checkForAdditionalProperties` method to the ListPrompt. The method returns a map of property names to values if an any additional properties were modified by the prompt (ex. variation values modified by the edit variable prompt)