### PR TITLE
chore: Update min node version to 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "build:watch": "watch 'yarn build' src"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16.0.0"
   },
   "bugs": "https://github.com/DevCycleHQ/cli/issues",
   "keywords": [


### PR DESCRIPTION
oclif uses the AbortController when parsing flag values which was added in node v15