### PR TITLE
chore: escape glob patterns for include exclude flags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,5 +36,4 @@
     "@typescript-eslint/explicit-module-boundary-types": "off"
   },
   "ignorePatterns": ["dist"]
-
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-sha256": "^0.9.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "minimatch": "^5.0.1",
+    "minimatch": "^9.0.0",
     "mocha-chai-jest-snapshot": "^1.1.4",
     "node-emoji": "^1.11.0",
     "open": "^8.4.2",

--- a/src/commands/cleanup/index.ts
+++ b/src/commands/cleanup/index.ts
@@ -1,4 +1,4 @@
-import minimatch from 'minimatch'
+import { minimatch } from 'minimatch'
 import { Flags, Args } from '@oclif/core'
 import chalk from 'chalk'
 import inquirer from '../../ui/autocomplete'
@@ -106,7 +106,7 @@ export default class Cleanup extends Base {
             const includeGlobs = flags['include'] || codeInsightsConfig.includeFiles
             return includeGlobs
                 ? includeGlobs.some((glob) =>
-                    minimatch(filepath, glob, { matchBase: true }),
+                    minimatch(filepath, minimatch.escape(glob), { matchBase: true }),
                 )
                 : true
         }
@@ -115,7 +115,7 @@ export default class Cleanup extends Base {
             const excludeGlobs = flags['exclude'] || codeInsightsConfig.excludeFiles
             return excludeGlobs
                 ? excludeGlobs.some((glob) =>
-                    minimatch(filepath, glob, { matchBase: true }),
+                    minimatch(filepath, minimatch.escape(glob), { matchBase: true }),
                 )
                 : false
         }

--- a/src/commands/usages/__snapshots__/usages.test.ts.snap
+++ b/src/commands/usages/__snapshots__/usages.test.ts.snap
@@ -19,6 +19,25 @@ DevCycle Variable Usage:
 "
 `;
 
+exports[`usages runs against a dart test file with special characters in the path 1`] = `
+"
+DevCycle Variable Usage:
+
+1. string-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L81
+2. boolean-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L92
+3. integer-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L102
+4. decimal-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L112
+5. json-array-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L122
+6. json-object-variable
+	- test-utils/fixtures/usages/[org_id]/sample.dart:L135
+"
+`;
+
 exports[`usages runs against a go test file 1`] = `
 "
 DevCycle Variable Usage:
@@ -78,6 +97,32 @@ DevCycle Variable Usage:
 "
 `;
 
+exports[`usages runs against a node test file with special characters in the path 1`] = `
+"
+DevCycle Variable Usage:
+
+1. special-character-path
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L1
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L2
+2. single-quotes
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L4
+3. multi-line
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L10
+4. multi-line-comment
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L20
+5. user-object
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L23
+6. user-constructor
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L24
+7. multi-line-user-object
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L25
+8. variable-from-api
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L35
+9. multiline-extra-comma
+	- test-utils/fixtures/usages/[org_id]/nodejs.js:L37
+"
+`;
+
 exports[`usages runs against a react test file 1`] = `
 "
 DevCycle Variable Usage:
@@ -86,5 +131,25 @@ DevCycle Variable Usage:
 	- test-utils/fixtures/usages/react.js:L1
 	- test-utils/fixtures/usages/react.js:L6
 	- test-utils/fixtures/usages/react.js:L11
+"
+`;
+
+exports[`usages runs against a react test file with special characters in the path 1`] = `
+"
+DevCycle Variable Usage:
+
+1. special-character-path
+	- test-utils/fixtures/usages/[org_id]/react.js:L1
+	- test-utils/fixtures/usages/[org_id]/react.js:L6
+	- test-utils/fixtures/usages/[org_id]/react.js:L11
+"
+`;
+
+exports[`usages runs against a react test file with special characters in the path 2`] = `
+"
+DevCycle Variable Usage:
+
+1. special-character-path
+	- test-utils/fixtures/usages/[org_id]/golang.go:L1
 "
 `;

--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -60,9 +60,9 @@ export default class Usages extends Base {
         const includeFile = (filepath: string) => {
             const includeGlobs = flags['include'] || codeInsightsConfig.includeFiles
             return includeGlobs
-                ? includeGlobs.some((glob) => {
-                    return minimatch(filepath, minimatch.escape(glob), { matchBase: true })
-                })
+                ? includeGlobs.some((glob) =>
+                    minimatch(filepath, minimatch.escape(glob), { matchBase: true })
+                )
                 : true
         }
 
@@ -179,7 +179,7 @@ export default class Usages extends Base {
         return Object.keys(matches).map((key) => {
             return {
                 key,
-                references: matches[key].map((match) => formatVariableMatchToReference(match)) 
+                references: matches[key].map((match) => formatVariableMatchToReference(match))
             }
         })
     }

--- a/src/commands/usages/index.ts
+++ b/src/commands/usages/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import minimatch from 'minimatch'
+import { minimatch } from 'minimatch'
 import { Flags } from '@oclif/core'
 import { lsFiles } from '../../utils/git/ls-files'
 import { parseFiles } from '../../utils/usages/parse'
@@ -60,14 +60,16 @@ export default class Usages extends Base {
         const includeFile = (filepath: string) => {
             const includeGlobs = flags['include'] || codeInsightsConfig.includeFiles
             return includeGlobs
-                ? includeGlobs.some((glob) => minimatch(filepath, glob, { matchBase: true }))
+                ? includeGlobs.some((glob) => {
+                    return minimatch(filepath, minimatch.escape(glob), { matchBase: true })
+                })
                 : true
         }
 
         const excludeFile = (filepath: string) => {
             const excludeGlobs = flags['exclude'] || codeInsightsConfig.excludeFiles
             return excludeGlobs
-                ? excludeGlobs.some((glob) => minimatch(filepath, glob, { matchBase: true }))
+                ? excludeGlobs.some((glob) => minimatch(filepath, minimatch.escape(glob), { matchBase: true }))
                 : false
         }
 
@@ -86,7 +88,7 @@ export default class Usages extends Base {
                 name: filepath,
                 lines
             }
-        } 
+        }
 
         const files = lsFiles()
             .filter((filepath) => includeFile(filepath) && !excludeFile(filepath))
@@ -104,7 +106,7 @@ export default class Usages extends Base {
         })
 
         const variableAliases = getVariableAliases(flags, this.repoConfig)
-        
+
         const usages = this.getMatchesByVariable(matchesBySdk, variableAliases)
         if (flags['only-unused']) {
             const variablesMap = (await fetchAllVariables(this.authToken, this.projectKey)).reduce((
@@ -120,7 +122,7 @@ export default class Usages extends Base {
                 }
             })
         }
-        
+
         if (flags['format'] === 'json') {
             const matchesByVariableJSON = this.formatMatchesToJSON(usages)
             this.log(JSON.stringify(matchesByVariableJSON, null, 2))

--- a/src/commands/usages/usages.test.ts
+++ b/src/commands/usages/usages.test.ts
@@ -7,7 +7,7 @@ import { BASE_URL } from '../../api/common'
 describe('usages', () => {
     beforeEach(setCurrentTestFile(__filename))
     chai.use(jestSnapshotPlugin())
-    
+
     const projectKey = 'test-project'
     const mockVariable = {
         '_id': '648a0d55c4e88cd4c4544c58',
@@ -30,17 +30,24 @@ describe('usages', () => {
         .it('runs against a node test file', (ctx) => {
             expect(ctx.stdout).toMatchSnapshot()
         })
-    
+
+    test
+        .stdout()
+        .command(['usages', '--include', 'test-utils/fixtures/usages/[org_id]/nodejs.js'])
+        .it('runs against a node test file with special characters in the path', (ctx) => {
+            expect(ctx.stdout).toMatchSnapshot()
+        })
+
     test
         .nock(BASE_URL, (api) => api
             .get(`/v1/projects/${projectKey}/variables?perPage=1000&page=1&status=active`)
             .reply(200, [mockVariable])
         ).stdout()
         .command([
-            'usages', 
-            '--only-unused', 
-            '--include', 
-            'test-utils/fixtures/usages/nodejs.js', 
+            'usages',
+            '--only-unused',
+            '--include',
+            'test-utils/fixtures/usages/nodejs.js',
             '--project',
             projectKey,
         ])
@@ -57,6 +64,13 @@ describe('usages', () => {
 
     test
         .stdout()
+        .command(['usages', '--include', 'test-utils/fixtures/usages/[org_id]/react.js'])
+        .it('runs against a react test file with special characters in the path', (ctx) => {
+            expect(ctx.stdout).toMatchSnapshot()
+        })
+
+    test
+        .stdout()
         .command(['usages', '--include', 'test-utils/fixtures/usages/golang.go'])
         .it('runs against a go test file', (ctx) => {
             expect(ctx.stdout).toMatchSnapshot()
@@ -64,8 +78,22 @@ describe('usages', () => {
 
     test
         .stdout()
+        .command(['usages', '--include', 'test-utils/fixtures/usages/[org_id]/golang.go'])
+        .it('runs against a react test file with special characters in the path', (ctx) => {
+            expect(ctx.stdout).toMatchSnapshot()
+        })
+
+    test
+        .stdout()
         .command(['usages', '--include', 'test-utils/fixtures/usages/sample.dart'])
         .it('runs against a dart test file', (ctx) => {
+            expect(ctx.stdout).toMatchSnapshot()
+        })
+
+    test
+        .stdout()
+        .command(['usages', '--include', 'test-utils/fixtures/usages/[org_id]/sample.dart'])
+        .it('runs against a dart test file with special characters in the path', (ctx) => {
             expect(ctx.stdout).toMatchSnapshot()
         })
 })

--- a/test-utils/fixtures/cleanup/javascript/[org_id]/test.js
+++ b/test-utils/fixtures/cleanup/javascript/[org_id]/test.js
@@ -1,0 +1,42 @@
+const simpleCaseValue = dvcClient.variable(user, "special-character-path", true).value
+const simpleCase = dvcClient.variable(user, "special-character-path", true)
+const isDefaulted = dvcClient.variable(user, "special-character-path", true).isDefaulted
+
+console.log('isDefaulted: ' + isDefaulted)
+console.log(dvcClient.variable(user, "special-character-path", true))
+
+if (simpleCaseValue === true) {
+    const someVar = dvcClient.variable(user, "some-var", "stringy")
+    const templateVar = `Hello, ${someVar}`
+    const concatVar = "Goodbye, " + someVar
+}
+
+if (simpleCase.value) {
+    // Simple Case is true
+    console.log('obj var .value is truthy')
+}
+
+if (simpleCaseValue === 3) {
+    console.log('value var === 3')
+}
+
+const x = simpleCaseValue ? 1 : 0
+
+if (dvcClient.variable(user, "special-character-path", true).value === true) {
+    console.log('obj.value === true')
+}
+
+if (dvcClient.variable(user, "special-character-path", true).value) {
+    console.log('obj.value is truthy')
+}
+
+console.log(dvcClient.variable(user, SIMPLE_CASE, true).value)
+
+console.log(useVariableValue("special-character-path", true))
+
+function hello() {
+    console.log("HELLO")
+    dvcClient.variable(user, "special-character-path", true).onUpdate((value) => {
+        heroText.innerHTML = value
+    })
+}

--- a/test-utils/fixtures/usages/[org_id]/golang.go
+++ b/test-utils/fixtures/usages/[org_id]/golang.go
@@ -1,0 +1,1 @@
+testVariable, _ := client.Variable(user, "special-character-path", "test")

--- a/test-utils/fixtures/usages/[org_id]/nodejs.js
+++ b/test-utils/fixtures/usages/[org_id]/nodejs.js
@@ -1,0 +1,40 @@
+dvcClient.variable(user, "special-character-path", true)
+dvcClient.variable(user, "special-character-path", false)
+
+dvcClient.variable(user, 'single-quotes', "word")
+
+checkVariable(user, "func-proxy", 7)
+
+myClient.variable(user, "alias-case", {})
+
+dvcClient
+    .variable(
+        user,
+        "multi-line",
+        true
+    )
+
+// dvcClient.variable(user, "single-comment", 10)
+
+/**
+ * dvcClient.variable(user, "multi-line-comment", false)
+ */
+
+dvcClient.variable({ user_id: "id", email: "blah" }, "user-object", true)
+dvcClient.variable(new User("user_id"), "user-constructor", true)
+dvcClient.variable(
+   {
+      user_id: "id",
+      email: "blah"
+    },
+   "multi-line-user-object",
+   true
+)
+dvcClient.variable(user, VARIABLES.ENUM_VARIABLE, true)
+dvc.variable(user, "renamed-case", true)
+dvcClient.variable(user, "variable-from-api", true)
+
+const assignedToAVar = useVariable(
+    'multiline-extra-comma',
+    false,
+)?.value

--- a/test-utils/fixtures/usages/[org_id]/react.js
+++ b/test-utils/fixtures/usages/[org_id]/react.js
@@ -1,0 +1,14 @@
+const assignedToAVar = useVariable(
+    'special-character-path',
+    false,
+)?.value
+
+useVariableValue(
+    'special-character-path',
+    false,
+)?.value
+
+useDVCVariable(
+    'special-character-path',
+    false,
+)?.value

--- a/test-utils/fixtures/usages/[org_id]/sample.dart
+++ b/test-utils/fixtures/usages/[org_id]/sample.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:devcycle_flutter_client_sdk/devcycle_flutter_client_sdk.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _logger = Logger();
+  String _platformVersion = 'Unknown';
+  String _displayValue = '';
+  String _variableValue = '';
+  bool _booleanValue = false;
+  num _integerValue = 0;
+  num _doubleValue = 0.0;
+  var _jsonArrayValue = '';
+  var _jsonObjectValue = '';
+
+  var encodedJsonArray = '''
+  [
+    {"score": 40},
+    {"score": 80}
+  ]
+''';
+  var encodedJsonObject = '''
+  {
+    "score1": 40,
+    "score2": 80
+  }
+''';
+
+  final _dvcClient = DVCClientBuilder()
+      .sdkKey('YOUR_DVC_MOBILE_SDK_KEY')
+      .user(DVCUserBuilder().userId('123').build())
+      .options(DVCOptionsBuilder().logLevel(LogLevel.debug).build())
+      .build();
+
+  @override
+  void initState() {
+    super.initState();
+    initPlatformState();
+    initVariable();
+  }
+
+  // Platform messages are asynchronous, so we initialize in an async method.
+  Future<void> initPlatformState() async {
+    String platformVersion;
+    // Platform messages may fail, so we use a try/catch PlatformException.
+    // We also handle the message potentially returning null.
+    try {
+      platformVersion =
+          await _dvcClient.getPlatformVersion() ?? 'Unknown platform version';
+    } on PlatformException {
+      platformVersion = 'Failed to get platform version.';
+    }
+
+    // If the widget was removed from the tree while the asynchronous platform
+    // message was in flight, we want to discard the reply rather than calling
+    // setState to update our non-existent appearance.
+    if (!mounted) return;
+
+    setState(() {
+      _platformVersion = platformVersion;
+    });
+  }
+
+  Future<void> initVariable() async {
+    final variable =
+        await _dvcClient.variable('string-variable', 'Default Value');
+    setState(() {
+      _variableValue = variable?.value;
+    });
+    variable?.onUpdate((updatedValue) {
+      setState(() {
+        _variableValue = updatedValue;
+      });
+    });
+
+    final booleanVariable =
+        await _dvcClient.variable('boolean-variable', false);
+    setState(() {
+      _booleanValue = booleanVariable?.value;
+    });
+    booleanVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _booleanValue = updatedValue;
+      });
+    });
+
+    final integerVariable = await _dvcClient.variable('integer-variable', 188);
+    setState(() {
+      _integerValue = integerVariable?.value;
+    });
+    integerVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _integerValue = updatedValue;
+      });
+    });
+
+    final doubleVariable = await _dvcClient.variable('decimal-variable', 1.88);
+    setState(() {
+      _doubleValue = doubleVariable?.value;
+    });
+    doubleVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _doubleValue = updatedValue;
+      });
+    });
+
+    final jsonArrayVariable = await _dvcClient.variable(
+      'json-array-variable',
+      jsonDecode(encodedJsonArray)
+    );
+    setState(() {
+      _jsonArrayValue = jsonEncode(jsonArrayVariable?.value);
+    });
+    jsonArrayVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _jsonArrayValue = jsonEncode(updatedValue);
+      });
+    });
+    
+    final jsonObjectVariable = await _dvcClient.variable(
+      'json-object-variable',
+      jsonDecode(encodedJsonObject)
+    );
+    setState(() {
+      _jsonObjectValue = jsonEncode(jsonObjectVariable?.value);
+    });
+    jsonObjectVariable?.onUpdate((updatedValue) {
+      setState(() {
+        _jsonObjectValue = jsonEncode(updatedValue);
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Plugin example app'),
+        ),
+        body: Center(
+            child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text("Value: $_variableValue"),
+            Text("Value: $_booleanValue"),
+            Text("Value: $_integerValue"),
+            Text("Value: $_doubleValue"),
+            Text("Value: $_jsonArrayValue"),
+            Text("Value: $_jsonObjectValue"),
+            Text('Running on: $_platformVersion\n'),
+            Icon(
+              Icons.star,
+              color: _booleanValue ? Colors.blue[500] : Colors.red[500],
+            ),
+            _booleanValue
+                ? const Icon(
+                    Icons.sentiment_very_satisfied,
+                    color: Colors.grey,
+                  )
+                : const Icon(
+                    Icons.sentiment_very_dissatisfied,
+                    color: Colors.grey,
+                  ),
+            ElevatedButton(
+                onPressed: showAllFeatures, child: const Text('All Features')),
+            ElevatedButton(
+                onPressed: showAllVariables,
+                child: const Text('All Variables')),
+            ElevatedButton(
+                onPressed: identifyUser, child: const Text('Identify User')),
+            ElevatedButton(
+                onPressed: identifyAnonUser,
+                child: const Text('Identify Anonymous User')),
+            ElevatedButton(
+                onPressed: resetUser, child: const Text('Reset User')),
+            ElevatedButton(
+                onPressed: trackEvent, child: const Text('Track Event')),
+            ElevatedButton(
+                onPressed: flushEvents, child: const Text('FlushEvents')),
+            Text(_displayValue)
+          ],
+        )),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Changes

- upgrade `minimatch` library
- use `minimatch.escape` to escape special characters for `include` and `exclude` flags so it can match on special characters when using `usages` and `cleanup`