### PR TITLE
Add prompt to create targets when enable an environment

### DIFF
--- a/src/commands/targeting/enable.ts
+++ b/src/commands/targeting/enable.ts
@@ -1,9 +1,9 @@
 import { Args } from '@oclif/core'
-import { enableTargeting } from '../../api/targeting'
+import { enableTargeting, fetchTargetingForFeature } from '../../api/targeting'
 import { Variation } from '../../api/schemas'
 import { renderTargetingTree } from '../../ui/targetingTree'
 import Base from '../base'
-import { getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
+import { createTargetAndEnable, getFeatureAndEnvironmentKeyFromArgs } from '../../utils/targeting'
 import { fetchAudiences } from '../../api/audiences'
 
 export default class EnableTargeting extends Base {
@@ -36,6 +36,24 @@ export default class EnableTargeting extends Base {
             args,
             flags,
         )
+        if (!headless) {
+            const [targetingRules] = await fetchTargetingForFeature(
+                this.authToken, this.projectKey, featureKey, environmentKey
+            )
+
+            if (targetingRules.targets.length === 0) {
+                await createTargetAndEnable(
+                    targetingRules.targets,
+                    featureKey,
+                    environmentKey,
+                    this.authToken, 
+                    this.projectKey, 
+                    this.writer
+                )
+                return
+            }
+        }
+
         const updatedTargeting = await enableTargeting(
             this.authToken,
             this.projectKey,

--- a/src/utils/features/quickCreateFeatureUtils.ts
+++ b/src/utils/features/quickCreateFeatureUtils.ts
@@ -42,7 +42,7 @@ export const setupTargetingForEnvironments = async (
         projectKey, 
         featureKey, 
         environment.key, {
-            targets: [{
+            targets: environment.type !== 'development' ? [] :[{
                 distribution: [{
                     percentage: 1,
                     _variation: 'variation-on',
@@ -59,6 +59,6 @@ export const setupTargetingForEnvironments = async (
                     }
                 }
             }],
-            status: environment.key === 'development' ? 'active' : 'inactive'
+            status: environment.type === 'development' ? 'active' : 'inactive'
         })))
 }


### PR DESCRIPTION
This prompt only shows up if you don't have any targeting rules, try to use `targeting update`, and then _only_ select `status` and set it to enabled. If you edit the targeting rules as part of the update it won't prompt to create one. Similarly, if you use the shortcut `targeting enable` it will trigger the prompt if you don't have any targeting rules. 

Selecting All Users just prompts to select variation and then creates the rule:

https://github.com/DevCycleHQ/cli/assets/25067948/ffdf8837-9431-49a7-9d66-6033dc0cfcf5



Selecting Custom Target prompts for name, variation, and filters:
<img width="695" alt="image" src="https://github.com/DevCycleHQ/cli/assets/25067948/7f1962f7-5ec9-4561-8f32-b57ca5c35503">

Selecting Cancel ends the command:
<img width="703" alt="image" src="https://github.com/DevCycleHQ/cli/assets/25067948/6ebb11a7-462f-48c7-b683-9222ced62ebb">


