### PR TITLE
chore: added linux-arm64 to list of uploaded artifacts

### DIFF
--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -45,6 +45,21 @@ runs:
         asset_name: dvc-${{ inputs.release-tag }}-linux-arm.tar.gz
         asset_content_type: application/gzip
 
+    - name: Get Path of linux-arm64 Artifact
+      id: linux-arm64-artifact
+      shell: bash
+      run: |
+        echo "ARTIFACT_PATH=$(ls dist/*-linux-arm.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Upload linux-arm64 Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ inputs.upload-url }}
+        asset_path: ${{ steps.linux-arm64-artifact.outputs.ARTIFACT_PATH }}
+        asset_name: dvc-${{ inputs.release-tag }}-linux-arm64.tar.gz
+        asset_content_type: application/gzip
+
     - name: Get Path of win32-x64 Artifact
       id: win32-x64-artifact
       shell: bash


### PR DESCRIPTION
# Changes

- added linux-arm64 to list of uploaded artifacts

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflow to include linux-arm64 in the list of uploaded artifacts, ensuring that this architecture is now supported in the release process.

* **Chores**:
    - Added linux-arm64 to the list of uploaded artifacts in the GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->