### PR TITLE
fix: renamed env variable to prevent collisions

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,5 +1,5 @@
 export const BASE_URL =
-    process.env.LOCAL === '1'
+    process.env.DVC_API_LOCAL === '1'
         ? 'http://localhost:4001'
         : 'https://api.devcycle.com'
 export const AUTH_URL = 'https://auth.devcycle.com/'


### PR DESCRIPTION
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a potential environment variable collision by renaming 'LOCAL' to 'DVC_API_LOCAL' in the API configuration.

* **Bug Fixes**:
    - Renamed environment variable from 'LOCAL' to 'DVC_API_LOCAL' to prevent collisions.

<!-- Generated by sourcery-ai[bot]: end summary -->