### PR TITLE
fix: added retry for connecting to a port not in use

### DIFF
--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.10",
+  "version": "5.14.11",
   "commands": {
     "authCommand": {
       "id": "authCommand",


### PR DESCRIPTION
# Changes

- when port is in use, add retry with another supported port to connect to

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
