### PR TITLE
fix: limit API error logs to only render for CLI use-cases, not for other callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ npm install -g @devcycle/cli
 $ dvc COMMAND
 running command...
 $ dvc (--version)
-@devcycle/cli/5.14.12 linux-x64 node-v20.10.0
+@devcycle/cli/5.14.12 darwin-arm64 node-v20.10.0
 $ dvc --help [COMMAND]
 USAGE
   $ dvc COMMAND

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.11",
+  "version": "5.14.12",
   "commands": {
     "authCommand": {
       "id": "authCommand",

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -26,14 +26,22 @@ axiosClient.interceptors.response.use(
         return response
     },
     (error: AxiosError) => {
+        let isCallerCli = false
+        if (error.config) {
+            const parsedDvcReferrerMetadata = JSON.parse(
+                error.config.headers['dvc-referrer-metadata'],
+            )
+            isCallerCli = parsedDvcReferrerMetadata.caller === 'cli'
+        }
+
         if (error.response?.status === 401) {
             console.info(
                 'Authorization Error: Please login using "dvc login again".',
             )
-        } else if (error.response?.data) {
+        } else if (isCallerCli && error.response?.data) {
             const responseData = error.response?.data as Record<string, any>
             console.info('DevCycle Error:', responseData?.message)
-        } else if (error) {
+        } else if (isCallerCli && error.code) {
             console.info('DevCycle Error:', error.code)
         }
         // TODO: Handle this error properly, DVC-7758

--- a/src/commands/diff/__snapshots__/diff.test.ts.snap
+++ b/src/commands/diff/__snapshots__/diff.test.ts.snap
@@ -37,6 +37,43 @@ The following variables that do not exist in DevCycle were cleaned up:
 "
 `;
 
+exports[`diff enriches output with API data when caller is github.pr_insights without outputting API Errors 1`] = `
+"
+DevCycle Variable Changes:
+
+⚠️   1 Variable With Notices
+🟢  2 Variables Added
+🔴  2 Variables Removed
+🧹  1 Variable Cleaned up
+
+⚠️  Notices
+
+  1. Variable \\"no-exists\\" does not exist on DevCycle
+
+🟢 Added
+
+  1. exists
+	   Type: String
+	   Location: test-utils/fixtures/diff/sampleDiff.js:L1
+  2. no-exists ⚠️
+	   Location: test-utils/fixtures/diff/sampleDiff.js:L2
+
+🔴 Removed
+
+  1. exists2
+	   Type: String
+	   Location: test-utils/fixtures/diff/sampleDiff.js:L1
+  2. no-exists2 🧹
+	   Location: test-utils/fixtures/diff/sampleDiff.js:L2
+
+🧹 Cleaned Up
+
+The following variables that do not exist in DevCycle were cleaned up:
+
+  1. no-exists2
+"
+`;
+
 exports[`diff formats the output as markdown 1`] = `
 "
 ## <img src=\\"https://github.com/DevCycleHQ/cli/raw/main/assets/togglebot.svg#gh-light-mode-only\\" height=\\"31px\\" align=\\"center\\"/><img src=\\"https://github.com/DevCycleHQ/cli/raw/main/assets/togglebot-white.svg#gh-dark-mode-only\\" height=\\"31px\\" align=\\"center\\"/> DevCycle Variable Changes:


### PR DESCRIPTION
- only logs API errors to `stdout` when the caller is the CLI
- adds test to to `diff` function to verify the `stdout` output