### PR TITLE
feat: add --no-browser-auth option for authenticating via the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This process will open browser windows to interact with the DevCycle universal l
 
 To switch organizations once logged in, the [`organizations select` command](docs/organizations.md) can be used.
 
+If executing the CLI in a containerized environment, please ensure one of the following PORTs can be accessed via Port Forwarding: 2194 (default), 2195, 2196 or 8080. This will allow the authentication process to complete and set the access token appropriately.
+
 ### Repo Init Command
 The [`repo init` command](docs/repo.md#dvc-repo-init) behaves in the same way as `login sso`, but creates a [repo configuration file](#repo-configuration) and stores the project and organization choices there instead.
 

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.13",
+  "version": "5.14.14",
   "commands": {
     "authCommand": {
       "id": "authCommand",
@@ -83,6 +83,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "org": {
           "name": "org",
@@ -175,6 +183,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -261,6 +277,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "key": {
           "name": "key",
@@ -359,6 +383,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "sortBy": {
           "name": "sortBy",
@@ -467,6 +499,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -553,6 +593,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "name": {
           "name": "name",
@@ -666,6 +714,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "alias": {
           "name": "alias",
           "type": "option",
@@ -769,6 +825,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "value": {
           "name": "value",
@@ -912,6 +976,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "include": {
           "name": "include",
@@ -1067,6 +1139,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "key": {
           "name": "key",
           "type": "option",
@@ -1188,6 +1268,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "keys": {
           "name": "keys",
           "type": "option",
@@ -1281,6 +1369,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -1368,6 +1464,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "name": {
           "name": "name",
@@ -1489,6 +1593,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "key": {
           "name": "key",
@@ -1613,6 +1725,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -1709,6 +1829,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "keys": {
           "name": "keys",
@@ -1823,6 +1951,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "search": {
           "name": "search",
           "type": "option",
@@ -1927,6 +2063,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "name": {
           "name": "name",
@@ -2055,6 +2199,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "output-dir": {
           "name": "output-dir",
           "type": "option",
@@ -2178,6 +2330,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -2265,6 +2425,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "userId": {
           "name": "userId",
@@ -2362,6 +2530,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "env": {
           "name": "env",
@@ -2470,6 +2646,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "org": {
           "name": "org",
           "type": "option",
@@ -2564,6 +2748,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "org": {
           "name": "org",
           "type": "option",
@@ -2657,6 +2849,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -2744,6 +2944,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -2833,6 +3041,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -2920,6 +3136,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "org": {
           "name": "org",
@@ -3013,6 +3237,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "all": {
           "name": "all",
@@ -3119,6 +3351,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "feature": {
           "name": "feature",
           "type": "option",
@@ -3219,6 +3459,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "columns": {
           "name": "columns",
@@ -3383,6 +3631,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "feature": {
           "name": "feature",
           "type": "option",
@@ -3488,6 +3744,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "key": {
           "name": "key",
           "type": "option",
@@ -3592,6 +3856,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -3679,6 +3951,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "sortBy": {
           "name": "sortBy",
@@ -3790,6 +4070,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -3877,6 +4165,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "org": {
           "name": "org",
@@ -3972,6 +4268,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "org": {
           "name": "org",
           "type": "option",
@@ -4064,6 +4368,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {}
@@ -4154,6 +4466,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -4253,6 +4573,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -4353,6 +4681,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -4450,6 +4786,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "targets": {
           "name": "targets",
@@ -4566,6 +4910,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "include": {
           "name": "include",
@@ -4707,6 +5059,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "key": {
           "name": "key",
           "type": "option",
@@ -4835,6 +5195,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "keys": {
           "name": "keys",
           "type": "option",
@@ -4947,6 +5315,14 @@
             "vscode_extension"
           ]
         },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
+        },
         "search": {
           "name": "search",
           "type": "option",
@@ -5051,6 +5427,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "name": {
           "name": "name",
@@ -5158,6 +5542,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "key": {
           "name": "key",
@@ -5268,6 +5660,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -5362,6 +5762,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         }
       },
       "args": {
@@ -5454,6 +5862,14 @@
             "cli",
             "vscode_extension"
           ]
+        },
+        "no-browser-auth": {
+          "name": "no-browser-auth",
+          "type": "boolean",
+          "description": "Disable automatic opening of a browser window",
+          "hidden": true,
+          "helpGroup": "Global",
+          "allowNo": false
         },
         "name": {
           "name": "name",

--- a/src/commands/authCommand.ts
+++ b/src/commands/authCommand.ts
@@ -123,6 +123,7 @@ export default abstract class AuthCommand extends Base {
 
     async selectOrganization(organization: Organization): Promise<string> {
         const { flags } = await this.parse(AuthCommand)
+        const noBrowser = flags['no-browser-auth']
         const { id, name, display_name } = organization
 
         const auth = new ApiAuth(
@@ -133,7 +134,7 @@ export default abstract class AuthCommand extends Base {
         let accessToken = await auth.getToken(flags, id)
         if (!accessToken) {
             const ssoAuth = new SSOAuth(this.writer, this.authPath)
-            const tokens = await ssoAuth.getAccessToken(organization)
+            const tokens = await ssoAuth.getAccessToken(noBrowser, organization)
             accessToken = tokens.accessToken
         }
 

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -86,6 +86,12 @@ export default abstract class Base extends Command {
             ],
             hidden: true,
         }),
+        'no-browser-auth': Flags.boolean({
+            description: 'Disable automatic opening of a browser window',
+            default: false,
+            helpGroup: 'Global',
+            hidden: true,
+        }),
     }
 
     authToken = ''
@@ -124,6 +130,7 @@ export default abstract class Base extends Command {
     }
     private async authorizeApi(): Promise<void> {
         const { flags } = await this.parse(this.constructor as typeof Base)
+        const noBrowser = flags['no-browser-auth']
         const auth = new ApiAuth(
             this.authPath,
             this.config.cacheDir,
@@ -134,7 +141,7 @@ export default abstract class Base extends Command {
 
         if (!this.personalAccessToken && this.userAuthRequired) {
             const ssoAuth = new SSOAuth(this.writer, this.authPath)
-            const tokens = await ssoAuth.getAccessToken()
+            const tokens = await ssoAuth.getAccessToken(noBrowser)
             this.personalAccessToken = tokens.personalAccessToken
         }
 

--- a/src/commands/login/sso.ts
+++ b/src/commands/login/sso.ts
@@ -10,8 +10,11 @@ export default class LoginSSO extends AuthCommand {
     static examples = []
 
     public async run(): Promise<void> {
+        const { flags } = await this.parse(LoginSSO)
+        const noBrowser = flags['no-browser-auth']
+
         const ssoAuth = new SSOAuth(this.writer, this.authPath)
-        const tokens = await ssoAuth.getAccessToken()
+        const tokens = await ssoAuth.getAccessToken(noBrowser)
         this.authToken = tokens.accessToken
         this.personalAccessToken = tokens.personalAccessToken
         await this.setOrganizationAndProject()


### PR DESCRIPTION
- feat: add --no-browser-auth option for authenticating via the CLI, primarily for use in environments that do not have access to a browser (i.e. running in some containers)