### PR TITLE
chore: updated to use v2 feature endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g @devcycle/cli
 $ dvc COMMAND
 running command...
 $ dvc (--version)
-@devcycle/cli/5.17.0 linux-x64 node-v20.10.0
+@devcycle/cli/5.17.0 darwin-arm64 node-v18.17.0
 $ dvc --help [COMMAND]
 USAGE
   $ dvc COMMAND

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.16.2",
+  "version": "5.17.0",
   "commands": {
     "authCommand": {
       "id": "authCommand",

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios'
 import { BASE_URL } from './common'
-import { createApiClient } from './zodClient'
+import { createApiClient, createV2ApiClient } from './zodClient'
 import { ZodIssueCode, ZodIssueOptionalMessage, ErrorMapCtx } from 'zod'
 
 export const axiosClient = axios.create({
@@ -98,3 +98,5 @@ export const apiClient = createApiClient(BASE_URL, {
     validate: 'request',
 })
 export default apiClient
+
+export const v2ApiClient = createV2ApiClient(BASE_URL)

--- a/src/api/features.ts
+++ b/src/api/features.ts
@@ -1,5 +1,9 @@
 import { AxiosError } from 'axios'
-import { v2ApiClient as apiClient, apiClient as apiV1Client } from './apiClient'
+import {
+    v2ApiClient as apiClient,
+    apiClient as apiV1Client,
+    axiosClient,
+} from './apiClient'
 import { CreateFeatureParams, Feature, UpdateFeatureParams } from './schemas'
 import 'reflect-metadata'
 import { buildHeaders } from './common'

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -34,8 +34,8 @@ export const CreateVariableDto = schemas.CreateVariableDto
 export type UpdateVariableParams = z.infer<typeof schemas.UpdateVariableDto>
 export const UpdateVariableDto = schemas.UpdateVariableDto
 
-export type CreateVariationParams = z.infer<typeof schemas.FeatureVariationDto>
-export const CreateVariationDto = schemas.FeatureVariationDto
+export type CreateVariationParams = z.infer<typeof schemas.CreateVariationDto>
+export const CreateVariationDto = schemas.CreateVariationDto
 
 export type UpdateVariationParams = Partial<CreateVariationParams>
 

--- a/src/api/variations.ts
+++ b/src/api/variations.ts
@@ -3,6 +3,7 @@ import apiClient from './apiClient'
 import { CreateVariationParams, Feature, Variation } from './schemas'
 import { buildHeaders } from './common'
 
+// TODO: Update these functions to use the new v2 API client once the v2 variations endpoint is implemented
 const variationsUrl = '/v1/projects/:project/features/:feature/variations'
 export class UpdateVariationParams {
     @IsString()

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -480,7 +480,7 @@ const Feature = z.object({
     tags: z.array(z.string()).optional(),
     ldLink: z.string().optional(),
     readonly: z.boolean(),
-    settings: FeatureSettings.optional(),
+    settings: FeatureSettings.partial(),
     sdkVisibility: FeatureSDKVisibility.optional(),
 })
 const PreconditionFailedErrorResponse = z.object({

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -359,6 +359,7 @@ const ReassociateVariableDto = z.object({
         .regex(/^[a-z0-9-_.]+$/),
 })
 const FeatureVariationDto = z.object({
+    _id: z.string(),
     key: z
         .string()
         .max(100)
@@ -405,7 +406,7 @@ const CreateFeatureDto = z.object({
             }),
         )
         .optional(),
-    variations: z.array(FeatureVariationDto).optional(),
+    variations: z.array(FeatureVariationDto.partial()).optional(),
     controlVariation: z.string().optional(),
     settings: FeatureSettingsDto.optional(),
     sdkVisibility: FeatureSDKVisibilityDto.optional(),
@@ -480,7 +481,7 @@ const Feature = z.object({
     tags: z.array(z.string()).optional(),
     ldLink: z.string().optional(),
     readonly: z.boolean(),
-    settings: FeatureSettings.partial(),
+    settings: FeatureSettings.partial().optional(),
     sdkVisibility: FeatureSDKVisibility.optional(),
 })
 const PreconditionFailedErrorResponse = z.object({

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -396,6 +396,15 @@ const CreateFeatureDto = z.object({
     variables: z
         .array(z.union([CreateVariableDto, ReassociateVariableDto]))
         .optional(),
+    configurations: z
+        .record(
+            z.string(),
+            z.object({
+                targets: z.array(z.any()).optional(),
+                status: z.string().optional(),
+            }),
+        )
+        .optional(),
     variations: z.array(FeatureVariationDto).optional(),
     controlVariation: z.string().optional(),
     settings: FeatureSettingsDto.optional(),
@@ -454,6 +463,14 @@ const Feature = z.object({
     ]),
     type: z.enum(['release', 'experiment', 'permission', 'ops']).optional(),
     status: z.enum(['active', 'complete', 'archived']).optional(),
+    configurations: z
+        .record(
+            z.string(),
+            z
+                .object({ targets: z.array(z.any()), status: z.string() })
+                .partial(),
+        )
+        .optional(),
     _createdBy: z.string().optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -432,6 +432,14 @@ const Variation = z.object({
         .optional(),
     _id: z.string(),
 })
+const CreateVariationDto = z.object({
+    key: z
+        .string()
+        .max(100)
+        .regex(/^[a-z0-9-_.]+$/),
+    name: z.string().max(100),
+    variables: z.record(z.any()).optional(),
+})
 const FeatureSettings = z.object({
     publicName: z.string().max(100),
     publicDescription: z.string().max(1000),
@@ -441,48 +449,6 @@ const FeatureSDKVisibility = z.object({
     mobile: z.boolean(),
     client: z.boolean(),
     server: z.boolean(),
-})
-const Feature = z.object({
-    name: z.string().max(100),
-    key: z
-        .string()
-        .max(100)
-        .regex(/^[a-z0-9-_.]+$/),
-    description: z.string().max(1000).optional(),
-    _id: z.string(),
-    _project: z.string(),
-    source: z.enum([
-        'api',
-        'dashboard',
-        'importer',
-        'github.code_usages',
-        'github.pr_insights',
-        'bitbucket.code_usages',
-        'bitbucket.pr_insights',
-        'terraform',
-        'cli',
-    ]),
-    type: z.enum(['release', 'experiment', 'permission', 'ops']).optional(),
-    status: z.enum(['active', 'complete', 'archived']).optional(),
-    configurations: z
-        .record(
-            z.string(),
-            z
-                .object({ targets: z.array(z.any()), status: z.string() })
-                .partial(),
-        )
-        .optional(),
-    _createdBy: z.string().optional(),
-    createdAt: z.string().datetime(),
-    updatedAt: z.string().datetime(),
-    variations: z.array(Variation),
-    controlVariation: z.string(),
-    variables: z.array(Variable),
-    tags: z.array(z.string()).optional(),
-    ldLink: z.string().optional(),
-    readonly: z.boolean(),
-    settings: FeatureSettings.partial().optional(),
-    sdkVisibility: FeatureSDKVisibility.optional(),
 })
 const PreconditionFailedErrorResponse = z.object({
     statusCode: z.number(),
@@ -611,6 +577,41 @@ const ResultSummaryDto = z.object({
         .partial(),
     cached: z.boolean(),
     updatedAt: z.string().datetime(),
+})
+const Feature = z.object({
+    name: z.string().max(100),
+    key: z
+        .string()
+        .max(100)
+        .regex(/^[a-z0-9-_.]+$/),
+    description: z.string().max(1000).optional(),
+    _id: z.string(),
+    _project: z.string(),
+    source: z.enum([
+        'api',
+        'dashboard',
+        'importer',
+        'github.code_usages',
+        'github.pr_insights',
+        'bitbucket.code_usages',
+        'bitbucket.pr_insights',
+        'terraform',
+        'cli',
+    ]),
+    type: z.enum(['release', 'experiment', 'permission', 'ops']).optional(),
+    status: z.enum(['active', 'complete', 'archived']).optional(),
+    configurations: z.array(FeatureConfig.partial()).optional(),
+    _createdBy: z.string().optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    variations: z.array(Variation),
+    controlVariation: z.string(),
+    variables: z.array(Variable),
+    tags: z.array(z.string()).optional(),
+    ldLink: z.string().optional(),
+    readonly: z.boolean(),
+    settings: FeatureSettings.partial().optional(),
+    sdkVisibility: FeatureSDKVisibility.optional(),
 })
 const FeatureDataPoint = z.object({
     values: z.object({}).partial(),
@@ -862,6 +863,7 @@ export const schemas = {
     FeatureSDKVisibilityDto,
     CreateFeatureDto,
     Variation,
+    CreateVariationDto,
     FeatureSettings,
     FeatureSDKVisibility,
     Feature,
@@ -2144,7 +2146,7 @@ const endpoints = makeApi([
             {
                 name: 'body',
                 type: 'Body',
-                schema: FeatureVariationDto,
+                schema: CreateVariationDto,
             },
             {
                 name: 'project',

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -3545,8 +3545,230 @@ const endpoints = makeApi([
     },
 ])
 
+const v2Endpoints = makeApi([
+    {
+        method: 'post',
+        path: '/v2/projects/:project/features',
+        alias: 'FeaturesController_create',
+        description: `Create a new Feature`,
+        requestFormat: 'json',
+        parameters: [
+            {
+                name: 'body',
+                type: 'Body',
+                schema: CreateFeatureDto,
+            },
+            {
+                name: 'project',
+                type: 'Path',
+                schema: z.string(),
+            },
+        ],
+        response: Feature,
+        errors: [
+            {
+                status: 400,
+                schema: BadRequestErrorResponse,
+            },
+            {
+                status: 401,
+                schema: z.void(),
+            },
+            {
+                status: 404,
+                schema: z.void(),
+            },
+            {
+                status: 409,
+                schema: ConflictErrorResponse,
+            },
+            {
+                status: 412,
+                schema: PreconditionFailedErrorResponse,
+            },
+        ],
+    },
+    {
+        method: 'get',
+        path: '/v2/projects/:project/features',
+        alias: 'FeaturesController_findAll',
+        description: `List Features`,
+        requestFormat: 'json',
+        parameters: [
+            {
+                name: 'page',
+                type: 'Query',
+                schema: z.number().gte(1).optional().default(1),
+            },
+            {
+                name: 'perPage',
+                type: 'Query',
+                schema: z.number().gte(1).lte(1000).optional().default(100),
+            },
+            {
+                name: 'sortBy',
+                type: 'Query',
+                schema: z
+                    .enum([
+                        'createdAt',
+                        'updatedAt',
+                        'name',
+                        'key',
+                        'createdBy',
+                        'propertyKey',
+                    ])
+                    .optional()
+                    .default('createdAt'),
+            },
+            {
+                name: 'sortOrder',
+                type: 'Query',
+                schema: z.enum(['asc', 'desc']).optional().default('desc'),
+            },
+            {
+                name: 'search',
+                type: 'Query',
+                schema: z.string().optional(),
+            },
+            {
+                name: 'createdBy',
+                type: 'Query',
+                schema: z.string().optional(),
+            },
+            {
+                name: 'type',
+                type: 'Query',
+                schema: z
+                    .enum(['release', 'experiment', 'permission', 'ops'])
+                    .optional(),
+            },
+            {
+                name: 'status',
+                type: 'Query',
+                schema: z.enum(['active', 'complete', 'archived']).optional(),
+            },
+            {
+                name: 'keys',
+                type: 'Query',
+                schema: z.array(z.string()).optional(),
+            },
+            {
+                name: 'includeLatestUpdate',
+                type: 'Query',
+                schema: z.boolean().optional(),
+            },
+            {
+                name: 'project',
+                type: 'Path',
+                schema: z.string(),
+            },
+        ],
+        response: z.array(Feature),
+        errors: [
+            {
+                status: 400,
+                schema: BadRequestErrorResponse,
+            },
+            {
+                status: 401,
+                schema: z.void(),
+            },
+            {
+                status: 404,
+                schema: z.void(),
+            },
+        ],
+    },
+    {
+        method: 'patch',
+        path: '/v2/projects/:project/features/:feature',
+        alias: 'FeaturesController_update',
+        description: `Update a Feature by ID or key`,
+        requestFormat: 'json',
+        parameters: [
+            {
+                name: 'body',
+                type: 'Body',
+                schema: UpdateFeatureDto,
+            },
+            {
+                name: 'feature',
+                type: 'Path',
+                schema: z.string(),
+            },
+            {
+                name: 'project',
+                type: 'Path',
+                schema: z.string(),
+            },
+        ],
+        response: Feature,
+        errors: [
+            {
+                status: 400,
+                schema: BadRequestErrorResponse,
+            },
+            {
+                status: 401,
+                schema: z.void(),
+            },
+            {
+                status: 403,
+                schema: z.void(),
+            },
+            {
+                status: 404,
+                schema: NotFoundErrorResponse,
+            },
+            {
+                status: 409,
+                schema: ConflictErrorResponse,
+            },
+            {
+                status: 412,
+                schema: PreconditionFailedErrorResponse,
+            },
+        ],
+    },
+    {
+        method: 'get',
+        path: '/v2/projects/:project/features/:key',
+        alias: 'FeaturesController_findOne',
+        description: `Get a Feature by ID or key`,
+        requestFormat: 'json',
+        parameters: [
+            {
+                name: 'key',
+                type: 'Path',
+                schema: z.string(),
+            },
+            {
+                name: 'project',
+                type: 'Path',
+                schema: z.string(),
+            },
+        ],
+        response: Feature,
+        errors: [
+            {
+                status: 401,
+                schema: z.void(),
+            },
+            {
+                status: 404,
+                schema: NotFoundErrorResponse,
+            },
+        ],
+    },
+])
+
 export const api = new Zodios(endpoints)
+export const v2Api = new Zodios(v2Endpoints)
 
 export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
     return new Zodios(baseUrl, endpoints, options)
+}
+
+export function createV2ApiClient(baseUrl: string, options?: ZodiosOptions) {
+    return new Zodios(baseUrl, v2Endpoints, options)
 }

--- a/src/auth/ApiAuth.ts
+++ b/src/auth/ApiAuth.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata'
 import jsYaml from 'js-yaml'
-import axios from 'axios'
 import fs from '../utils/fileSystem'
 import { plainToClass } from 'class-transformer'
 import { validateSync } from 'class-validator'
@@ -11,6 +10,7 @@ import { TokenCache } from './TokenCache'
 import { getOrgIdFromToken, getTokenExpiry, shouldRefreshToken } from './utils'
 import { CLI_CLIENT_ID } from './SSOAuth'
 import Writer from '../ui/writer'
+import axios from 'axios'
 
 type SupportedFlags = {
     'client-id'?: string

--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -106,7 +106,7 @@ describe('diff', () => {
             '--project',
             'project',
         ])
-        .catch((err) => null)
+        .catch((error) => null)
         .it('runs with failed api authorization', (ctx) => {
             expect(ctx.stderr).to.contain(
                 'Failed to authenticate with the DevCycle API. Check your credentials.',

--- a/src/commands/features/__snapshots__/update.test.ts.snap
+++ b/src/commands/features/__snapshots__/update.test.ts.snap
@@ -14,10 +14,12 @@ exports[`features update accepts flags and prompts for missing fields 1`] = `
   \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"variations\\": [],
+  \\"controlVariation\\": \\"variation_id\\",
   \\"variables\\": [],
   \\"tags\\": [],
   \\"ldLink\\": \\"string\\",
   \\"readonly\\": true,
+  \\"settings\\": {},
   \\"sdkVisibility\\": {
     \\"mobile\\": true,
     \\"client\\": true,
@@ -36,10 +38,12 @@ exports[`features update accepts flags and prompts for missing fields 1`] = `
   \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"variations\\": [],
+  \\"controlVariation\\": \\"variation_id\\",
   \\"variables\\": [],
   \\"tags\\": [],
   \\"ldLink\\": \\"string\\",
   \\"readonly\\": true,
+  \\"settings\\": {},
   \\"sdkVisibility\\": {
     \\"mobile\\": true,
     \\"client\\": true,
@@ -63,10 +67,12 @@ exports[`features update updates a feature after prompting for all fields 1`] = 
   \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"variations\\": [],
+  \\"controlVariation\\": \\"variation_id\\",
   \\"variables\\": [],
   \\"tags\\": [],
   \\"ldLink\\": \\"string\\",
   \\"readonly\\": true,
+  \\"settings\\": {},
   \\"sdkVisibility\\": {
     \\"mobile\\": true,
     \\"client\\": true,
@@ -88,10 +94,12 @@ exports[`features update updates a feature after prompting for all fields 1`] = 
   \\"createdAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"updatedAt\\": \\"2019-08-24T14:15:22Z\\",
   \\"variations\\": [],
+  \\"controlVariation\\": \\"variation_id\\",
   \\"variables\\": [],
   \\"tags\\": [],
   \\"ldLink\\": \\"string\\",
   \\"readonly\\": true,
+  \\"settings\\": {},
   \\"sdkVisibility\\": {
     \\"mobile\\": true,
     \\"client\\": true,
@@ -102,6 +110,6 @@ exports[`features update updates a feature after prompting for all fields 1`] = 
 `;
 
 exports[`features update updates a feature in headless mode 1`] = `
-"{\\"name\\":\\"Feature Name\\",\\"key\\":\\"feature-key\\",\\"_id\\":\\"id\\",\\"_project\\":\\"string\\",\\"source\\":\\"api\\",\\"_createdBy\\":\\"string\\",\\"createdAt\\":\\"2019-08-24T14:15:22Z\\",\\"updatedAt\\":\\"2019-08-24T14:15:22Z\\",\\"variations\\":[],\\"variables\\":[],\\"tags\\":[],\\"ldLink\\":\\"string\\",\\"readonly\\":true,\\"sdkVisibility\\":{\\"mobile\\":true,\\"client\\":true,\\"server\\":true}}
+"{\\"name\\":\\"Feature Name\\",\\"key\\":\\"feature-key\\",\\"_id\\":\\"id\\",\\"_project\\":\\"string\\",\\"source\\":\\"api\\",\\"_createdBy\\":\\"string\\",\\"createdAt\\":\\"2019-08-24T14:15:22Z\\",\\"updatedAt\\":\\"2019-08-24T14:15:22Z\\",\\"variations\\":[],\\"controlVariation\\":\\"variation_id\\",\\"variables\\":[],\\"tags\\":[],\\"ldLink\\":\\"string\\",\\"readonly\\":true,\\"settings\\":{},\\"sdkVisibility\\":{\\"mobile\\":true,\\"client\\":true,\\"server\\":true}}
 "
 `;

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -28,24 +28,6 @@ describe('features create', () => {
         },
     }
 
-    const mockEnvironments = [
-        {
-            key: 'development',
-            name: 'Development',
-            _id: '647f62ae749bbe90fb222070',
-        },
-        {
-            key: 'staging',
-            name: 'Staging',
-            _id: '637cfe8195279288bc08cb62',
-        },
-        {
-            key: 'production',
-            name: 'Production',
-            _id: '637cfe8195279288bc08cb61',
-        },
-    ]
-
     const mockFeature = {
         name: 'Feature Name',
         key: 'feature-key',
@@ -58,11 +40,7 @@ describe('features create', () => {
         variations: [],
         variables: [],
         tags: [],
-        configurations: {
-            development: {},
-            staging: {},
-            production: {},
-        },
+        configurations: [],
         ldLink: 'string',
         controlVariation: 'variation_id',
         readonly: true,

--- a/src/commands/features/create.test.ts
+++ b/src/commands/features/create.test.ts
@@ -64,13 +64,14 @@ describe('features create', () => {
             production: {},
         },
         ldLink: 'string',
-        controlVariation: 'variation_id_bruh',
+        controlVariation: 'variation_id',
         readonly: true,
         sdkVisibility: {
             mobile: true,
             client: true,
             server: true,
         },
+        settings: {},
     }
 
     const testSDKVisibility = {

--- a/src/commands/features/create.ts
+++ b/src/commands/features/create.ts
@@ -10,10 +10,7 @@ import { VariableListOptions } from '../../ui/prompts/listPrompts/variablesListP
 import { Flags } from '@oclif/core'
 import { CreateFeatureDto, Feature } from '../../api/schemas'
 import { VariationListOptions } from '../../ui/prompts/listPrompts/variationsListPrompt'
-import {
-    getQuickConfigurations,
-    mergeQuickFeatureParamsWithAnswers,
-} from '../../utils/features/quickCreateFeatureUtils'
+import { mergeQuickFeatureParamsWithAnswers } from '../../utils/features/quickCreateFeatureUtils'
 import { fetchProject } from '../../api/projects'
 
 export default class CreateFeature extends CreateCommand {

--- a/src/commands/features/create.ts
+++ b/src/commands/features/create.ts
@@ -11,8 +11,8 @@ import { Flags } from '@oclif/core'
 import { CreateFeatureDto, Feature } from '../../api/schemas'
 import { VariationListOptions } from '../../ui/prompts/listPrompts/variationsListPrompt'
 import {
+    getQuickConfigurations,
     mergeQuickFeatureParamsWithAnswers,
-    setupTargetingForEnvironments,
 } from '../../utils/features/quickCreateFeatureUtils'
 import { fetchProject } from '../../api/projects'
 
@@ -71,11 +71,6 @@ export default class CreateFeature extends CreateCommand {
                 this.authToken,
                 this.projectKey,
                 featureParams,
-            )
-            await setupTargetingForEnvironments(
-                this.authToken,
-                this.projectKey,
-                feature.key,
             )
             this.writer.showResults(feature)
             this.showSuggestedCommand(feature)

--- a/src/commands/features/get.test.ts
+++ b/src/commands/features/get.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@oclif/test'
-import { dvcTest } from '../../../test-utils'
+import { dvcTest, mockFeatures } from '../../../test-utils'
 import { BASE_URL } from '../../api/common'
 
 describe('features get', () => {
@@ -9,53 +9,6 @@ describe('features get', () => {
         'test-client-id',
         '--client-secret',
         'test-client-secret',
-    ]
-
-    const mockFeatures = [
-        {
-            key: 'feature-1',
-            name: 'Feature 1',
-            _id: '61450f3daec96f5cf4a49946',
-            _project: 'test-project',
-            source: 'api',
-            _createdBy: 'test-user',
-            createdAt: '2021-09-15T12:00:00Z',
-            updatedAt: '2021-09-15T12:00:00Z',
-            variations: [],
-            variables: [],
-            tags: [],
-            configurations: {},
-            sdkVisibility: {
-                mobile: true,
-                client: true,
-                server: true,
-            },
-            settings: {},
-            readonly: false,
-            controlVariation: 'control',
-        },
-        {
-            key: 'feature-2',
-            name: 'Feature 2',
-            _id: '61450f3daec96f5cf4a49947',
-            _project: 'test-project',
-            source: 'api',
-            _createdBy: 'test-user',
-            createdAt: '2021-09-15T12:00:00Z',
-            updatedAt: '2021-09-15T12:00:00Z',
-            variations: [],
-            variables: [],
-            tags: [],
-            configurations: {},
-            sdkVisibility: {
-                mobile: true,
-                client: true,
-                server: true,
-            },
-            settings: {},
-            readonly: false,
-            controlVariation: 'control',
-        },
     ]
 
     const verifyOutput = (output: any[]) => {

--- a/src/commands/features/get.test.ts
+++ b/src/commands/features/get.test.ts
@@ -16,30 +16,70 @@ describe('features get', () => {
             key: 'feature-1',
             name: 'Feature 1',
             _id: '61450f3daec96f5cf4a49946',
+            _project: 'test-project',
+            source: 'api',
+            _createdBy: 'test-user',
+            createdAt: '2021-09-15T12:00:00Z',
+            updatedAt: '2021-09-15T12:00:00Z',
+            variations: [],
+            variables: [],
+            tags: [],
+            configurations: {},
+            sdkVisibility: {
+                mobile: true,
+                client: true,
+                server: true,
+            },
+            settings: {},
+            readonly: false,
+            controlVariation: 'control',
         },
         {
             key: 'feature-2',
             name: 'Feature 2',
             _id: '61450f3daec96f5cf4a49947',
+            _project: 'test-project',
+            source: 'api',
+            _createdBy: 'test-user',
+            createdAt: '2021-09-15T12:00:00Z',
+            updatedAt: '2021-09-15T12:00:00Z',
+            variations: [],
+            variables: [],
+            tags: [],
+            configurations: {},
+            sdkVisibility: {
+                mobile: true,
+                client: true,
+                server: true,
+            },
+            settings: {},
+            readonly: false,
+            controlVariation: 'control',
         },
     ]
+
+    const verifyOutput = (output: any[]) => {
+        output.forEach((feature: any, index: number) => {
+            expect(feature).to.deep.equal(mockFeatures[index])
+        })
+    }
 
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .reply(200, mockFeatures),
         )
         .stdout()
         .command(['features get', '--project', projectKey, ...authFlags])
         .it('returns a list of feature objects', (ctx) => {
-            expect(ctx.stdout).to.contain(JSON.stringify(mockFeatures, null, 2))
+            verifyOutput(JSON.parse(ctx.stdout))
         })
 
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .query({ page: 2, perPage: 10 })
                 .reply(200, mockFeatures),
         )
@@ -55,13 +95,13 @@ describe('features get', () => {
             ...authFlags,
         ])
         .it('passes pagination params to api', (ctx) => {
-            expect(ctx.stdout).to.contain(JSON.stringify(mockFeatures, null, 2))
+            verifyOutput(JSON.parse(ctx.stdout))
         })
 
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .query({ search: 'hello world' })
                 .reply(200, mockFeatures),
         )
@@ -75,6 +115,6 @@ describe('features get', () => {
             ...authFlags,
         ])
         .it('passes search param to api', (ctx) => {
-            expect(ctx.stdout).to.contain(JSON.stringify(mockFeatures, null, 2))
+            verifyOutput(JSON.parse(ctx.stdout))
         })
 })

--- a/src/commands/features/list.test.ts
+++ b/src/commands/features/list.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@oclif/test'
-import { dvcTest } from '../../../test-utils'
+import { dvcTest, mockFeatures } from '../../../test-utils'
 import { BASE_URL } from '../../api/common'
 
 describe('features list', () => {
@@ -11,23 +11,10 @@ describe('features list', () => {
         'test-client-secret',
     ]
 
-    const mockFeatures = [
-        {
-            key: 'feature-1',
-            name: 'Feature 1',
-            _id: '61450f3daec96f5cf4a49946',
-        },
-        {
-            key: 'feature-2',
-            name: 'Feature 2',
-            _id: '61450f3daec96f5cf4a49947',
-        },
-    ]
-
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .reply(200, mockFeatures),
         )
         .stdout()
@@ -41,7 +28,7 @@ describe('features list', () => {
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .query({ page: 2, perPage: 10 })
                 .reply(200, mockFeatures),
         )
@@ -65,7 +52,7 @@ describe('features list', () => {
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features`)
+                .get(`/v2/projects/${projectKey}/features`)
                 .query({ search: 'hello world' })
                 .reply(200, mockFeatures),
         )

--- a/src/commands/features/update.test.ts
+++ b/src/commands/features/update.test.ts
@@ -43,6 +43,8 @@ describe('features update', () => {
             client: true,
             server: true,
         },
+        settings: {},
+        controlVariation: 'variation_id',
     }
 
     const testSDKVisibility = {
@@ -72,13 +74,13 @@ describe('features update', () => {
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+                .get(`/v2/projects/${projectKey}/features/${mockFeature.key}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>
             api
                 .patch(
-                    `/v1/projects/${projectKey}/features/${mockFeature.key}`,
+                    `/v2/projects/${projectKey}/features/${mockFeature.key}`,
                     requestBodyWithVariables,
                 )
                 .reply(200, mockFeature),
@@ -142,13 +144,13 @@ describe('features update', () => {
         }))
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+                .get(`/v2/projects/${projectKey}/features/${mockFeature.key}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>
             api
                 .patch(
-                    `/v1/projects/${projectKey}/features/${mockFeature.key}`,
+                    `/v2/projects/${projectKey}/features/${mockFeature.key}`,
                     requestBodyWithVariations,
                 )
                 .reply(200, mockFeature),
@@ -175,13 +177,13 @@ describe('features update', () => {
         }))
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${mockFeature.key}`)
+                .get(`/v2/projects/${projectKey}/features/${mockFeature.key}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>
             api
                 .patch(
-                    `/v1/projects/${projectKey}/features/${mockFeature.key}`,
+                    `/v2/projects/${projectKey}/features/${mockFeature.key}`,
                     requestBody,
                 )
                 .reply(200, mockFeature),

--- a/src/commands/variables/create.test.ts
+++ b/src/commands/variables/create.test.ts
@@ -30,18 +30,18 @@ describe('variables create', () => {
         createdAt: '2023-06-14T18:56:21.270Z',
         updatedAt: '2023-06-14T18:56:21.270Z',
     }
+    const variableRequestBody = {
+        _feature: featureId,
+        key: mockVariable.key,
+        type: mockVariable.type,
+        name: mockVariable.name,
+    }
     const mockFeature = {
         key: 'spam',
-        variables: [
-            {
-                _feature: featureId,
-                key: mockVariable.key,
-                type: mockVariable.type,
-                name: mockVariable.name,
-            },
-        ],
+        variables: [mockVariable],
         variations: [
             {
+                _id: 'variation-1-id',
                 key: 'variation-on',
                 name: 'Variation On',
                 variables: {
@@ -49,6 +49,7 @@ describe('variables create', () => {
                 },
             },
             {
+                _id: 'variation-1-id',
                 key: 'variation-off',
                 name: 'Variation Off',
                 variables: {
@@ -56,6 +57,23 @@ describe('variables create', () => {
                 },
             },
         ],
+        name: 'Test Feature',
+        description: 'A test feature for variable creation',
+        _id: featureId,
+        _project: projectKey,
+        source: 'api',
+        type: 'release',
+        _createdBy: 'test-user',
+        createdAt: '2023-06-14T18:56:21.270Z',
+        updatedAt: '2023-06-14T18:56:21.270Z',
+        controlVariation: 'variation-off',
+        readonly: false,
+        sdkVisibility: {
+            mobile: true,
+            client: true,
+            server: true,
+        },
+        settings: {},
     }
     // Headless mode
     dvcTest()
@@ -134,28 +152,21 @@ describe('variables create', () => {
 
     dvcTest()
         .nock(BASE_URL, (api) =>
+            // Get a feature that has no variables that will be patched with a variable afterwards
             api
-                .get(`/v1/projects/${projectKey}/features/${featureId}`)
+                .get(`/v2/projects/${projectKey}/features/${featureId}`)
                 .reply(200, {
-                    key: mockVariable.key,
-                    _id: featureId,
-                    variations: [
-                        {
-                            _id: '64b05702053947be0d079ef3',
-                            key: 'variation-on',
-                            name: 'Variation On',
-                            variables: {},
-                        },
-                        {
-                            _id: '64b05702053947be0d079ef4',
-                            key: 'variation-off',
-                            name: 'Variation Off',
-                            variables: {},
-                        },
-                    ],
+                    ...mockFeature,
+                    variations: mockFeature.variations.map((variation) => ({
+                        ...variation,
+                        variables: {},
+                    })),
                     variables: [],
                 })
-                .patch(`/v1/projects/${projectKey}/features/spam`, mockFeature)
+                .patch(`/v2/projects/${projectKey}/features/spam`, {
+                    variables: [variableRequestBody],
+                    variations: mockFeature.variations,
+                })
                 .reply(200, mockFeature),
         )
         .stdout()

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -72,13 +72,13 @@ export default class CreateVariable extends CreateCommand {
                     token: this.authToken,
                     projectKey: this.projectKey,
                 })
+                console.error('feature', feature)
                 if (!feature) {
                     this.writer.showError(
                         `Feature with key ${feature.key} could not be found`,
                     )
                     return
                 }
-                feature.variables.push(params)
                 const variableListOptions = new VariableListOptions(
                     [params as Variable],
                     this.writer,
@@ -87,11 +87,19 @@ export default class CreateVariable extends CreateCommand {
                 await variableListOptions.promptVariationValues(
                     params as Variable,
                 )
+
+                const updatedVariables = feature.variables
+                updatedVariables.push(params as Variable)
+                const updatedVariations = variableListOptions.featureVariations
+
                 await updateFeature(
                     this.authToken,
                     this.projectKey,
                     feature.key,
-                    feature,
+                    {
+                        variables: updatedVariables,
+                        variations: updatedVariations,
+                    },
                 )
                 const message =
                     `The variable was associated to the existing feature ${feature.key}. ` +
@@ -122,9 +130,10 @@ export default class CreateVariable extends CreateCommand {
                 const featureVariables = feature.variables
                 const featureVariations = feature.variations
                 featureVariables.push(params as Variable)
-                for (const vari of featureVariations) {
-                    vari.variables = vari.variables || {}
-                    vari.variables[params.key] = parsedVariations[vari.key]
+                for (const featVar of featureVariations) {
+                    featVar.variables = featVar.variables || {}
+                    featVar.variables[params.key] =
+                        parsedVariations[featVar.key]
                 }
                 await updateFeature(
                     this.authToken,

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -72,13 +72,6 @@ export default class CreateVariable extends CreateCommand {
                     token: this.authToken,
                     projectKey: this.projectKey,
                 })
-                console.error('feature', feature)
-                if (!feature) {
-                    this.writer.showError(
-                        `Feature with key ${feature.key} could not be found`,
-                    )
-                    return
-                }
                 const variableListOptions = new VariableListOptions(
                     [params as Variable],
                     this.writer,

--- a/src/commands/variables/create.ts
+++ b/src/commands/variables/create.ts
@@ -119,8 +119,10 @@ export default class CreateVariable extends CreateCommand {
                     return
                 }
                 const parsedVariations = JSON.parse(variations as string)
-                feature.variables.push(params as Variable)
-                for (const vari of feature.variations) {
+                const featureVariables = feature.variables
+                const featureVariations = feature.variations
+                featureVariables.push(params as Variable)
+                for (const vari of featureVariations) {
                     vari.variables = vari.variables || {}
                     vari.variables[params.key] = parsedVariations[vari.key]
                 }
@@ -128,7 +130,10 @@ export default class CreateVariable extends CreateCommand {
                     this.authToken,
                     this.projectKey,
                     feature.key,
-                    feature,
+                    {
+                        variations: featureVariations,
+                        variables: featureVariables,
+                    },
                 )
                 const message =
                     `The variable was associated to the existing feature ${feature.key}. ` +

--- a/src/commands/variations/__snapshots__/create.test.ts.snap
+++ b/src/commands/variations/__snapshots__/create.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`variations create creates a variation and returns the full feature in headless mode 1`] = `
-"{\\"_id\\":\\"63b5eea3e6e91987bae47f3a\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"source\\":\\"dashboard\\",\\"type\\":\\"experiment\\",\\"name\\":\\"First Feature\\",\\"description\\":\\"\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.870Z\\",\\"updatedAt\\":\\"2023-06-16T19:27:14.862Z\\",\\"variations\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f40\\",\\"key\\":\\"yo\\",\\"name\\":\\"Yo\\",\\"variables\\":{\\"new-variable\\":false,\\"first-feature\\":true}},{\\"_id\\":\\"63b5eea3e6e91987bae47f41\\",\\"key\\":\\"variation-a\\",\\"name\\":\\"Variation A\\",\\"variables\\":{}},{\\"_id\\":\\"63b5eea3e6e91987bae47f42\\",\\"key\\":\\"variation-b\\",\\"name\\":\\"Variation B\\",\\"variables\\":{}}],\\"controlVariation\\":\\"control\\",\\"variables\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f3c\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"_feature\\":\\"63b5eea3e6e91987bae47f3a\\",\\"name\\":\\"first-feature\\",\\"key\\":\\"first-feature\\",\\"type\\":\\"Boolean\\",\\"status\\":\\"active\\",\\"defaultValue\\":false,\\"source\\":\\"dashboard\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.877Z\\",\\"updatedAt\\":\\"2023-01-04T21:24:51.877Z\\"}],\\"tags\\":[],\\"readonly\\":false,\\"settings\\":{\\"optInEnabled\\":false,\\"publicName\\":\\"\\",\\"publicDescription\\":\\"\\"},\\"sdkVisibility\\":{\\"client\\":false,\\"mobile\\":false,\\"server\\":true}}
+"{\\"_id\\":\\"63b5eea3e6e91987bae47f3a\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"source\\":\\"dashboard\\",\\"type\\":\\"experiment\\",\\"name\\":\\"First Feature\\",\\"description\\":\\"\\",\\"key\\":\\"first-feature\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.870Z\\",\\"updatedAt\\":\\"2023-06-16T19:27:14.862Z\\",\\"variations\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f40\\",\\"key\\":\\"yo\\",\\"name\\":\\"Yo\\",\\"variables\\":{\\"new-variable\\":false,\\"first-feature\\":true}},{\\"_id\\":\\"63b5eea3e6e91987bae47f41\\",\\"key\\":\\"variation-a\\",\\"name\\":\\"Variation A\\",\\"variables\\":{}},{\\"_id\\":\\"63b5eea3e6e91987bae47f42\\",\\"key\\":\\"variation-b\\",\\"name\\":\\"Variation B\\",\\"variables\\":{}}],\\"controlVariation\\":\\"control\\",\\"variables\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f3c\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"_feature\\":\\"63b5eea3e6e91987bae47f3a\\",\\"name\\":\\"first-feature\\",\\"key\\":\\"first-feature\\",\\"type\\":\\"Boolean\\",\\"status\\":\\"active\\",\\"defaultValue\\":false,\\"source\\":\\"dashboard\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.877Z\\",\\"updatedAt\\":\\"2023-01-04T21:24:51.877Z\\"}],\\"tags\\":[],\\"readonly\\":false,\\"settings\\":{\\"optInEnabled\\":false,\\"publicName\\":\\"\\",\\"publicDescription\\":\\"\\"},\\"sdkVisibility\\":{\\"client\\":false,\\"mobile\\":false,\\"server\\":true}}
 "
 `;
 
@@ -13,6 +13,7 @@ exports[`variations create creates a variation and returns the full feature in i
   \\"type\\": \\"experiment\\",
   \\"name\\": \\"First Feature\\",
   \\"description\\": \\"\\",
+  \\"key\\": \\"first-feature\\",
   \\"_createdBy\\": \\"google-oauth2|111559006563333334214\\",
   \\"createdAt\\": \\"2023-01-04T21:24:51.870Z\\",
   \\"updatedAt\\": \\"2023-06-16T19:27:14.862Z\\",
@@ -86,6 +87,7 @@ exports[`variations create prompts for missing fields in interactive mode 1`] = 
   \\"type\\": \\"experiment\\",
   \\"name\\": \\"First Feature\\",
   \\"description\\": \\"\\",
+  \\"key\\": \\"first-feature\\",
   \\"_createdBy\\": \\"google-oauth2|111559006563333334214\\",
   \\"createdAt\\": \\"2023-01-04T21:24:51.870Z\\",
   \\"updatedAt\\": \\"2023-06-16T19:27:14.862Z\\",

--- a/src/commands/variations/__snapshots__/update.test.ts.snap
+++ b/src/commands/variations/__snapshots__/update.test.ts.snap
@@ -21,6 +21,7 @@ exports[`variations update prompts for variables when missing in interactive mod
   \\"source\\": \\"dashboard\\",
   \\"type\\": \\"experiment\\",
   \\"name\\": \\"First Feature\\",
+  \\"key\\": \\"first-feature\\",
   \\"description\\": \\"\\",
   \\"_createdBy\\": \\"google-oauth2|111559006563333334214\\",
   \\"createdAt\\": \\"2023-01-04T21:24:51.870Z\\",
@@ -82,7 +83,7 @@ exports[`variations update prompts for variables when missing in interactive mod
 `;
 
 exports[`variations update updates a variation and returns the full feature in headless mode 1`] = `
-"{\\"_id\\":\\"63b5eea3e6e91987bae47f3a\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"source\\":\\"dashboard\\",\\"type\\":\\"experiment\\",\\"name\\":\\"First Feature\\",\\"description\\":\\"\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.870Z\\",\\"updatedAt\\":\\"2023-06-16T19:27:14.862Z\\",\\"variations\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f40\\",\\"key\\":\\"yo\\",\\"name\\":\\"Yo\\",\\"variables\\":{\\"new-variable\\":false,\\"first-feature\\":true}},{\\"_id\\":\\"63b5eea3e6e91987bae47f41\\",\\"key\\":\\"variation-a\\",\\"name\\":\\"Variation A\\",\\"variables\\":{}},{\\"_id\\":\\"63b5eea3e6e91987bae47f42\\",\\"key\\":\\"variation-b\\",\\"name\\":\\"Variation B\\",\\"variables\\":{}}],\\"controlVariation\\":\\"control\\",\\"variables\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f3c\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"_feature\\":\\"63b5eea3e6e91987bae47f3a\\",\\"name\\":\\"first-feature\\",\\"key\\":\\"first-feature\\",\\"type\\":\\"Boolean\\",\\"status\\":\\"active\\",\\"defaultValue\\":false,\\"source\\":\\"dashboard\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.877Z\\",\\"updatedAt\\":\\"2023-01-04T21:24:51.877Z\\"}],\\"tags\\":[],\\"readonly\\":false,\\"settings\\":{\\"optInEnabled\\":false,\\"publicName\\":\\"\\",\\"publicDescription\\":\\"\\"},\\"sdkVisibility\\":{\\"client\\":false,\\"mobile\\":false,\\"server\\":true}}
+"{\\"_id\\":\\"63b5eea3e6e91987bae47f3a\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"source\\":\\"dashboard\\",\\"type\\":\\"experiment\\",\\"name\\":\\"First Feature\\",\\"key\\":\\"first-feature\\",\\"description\\":\\"\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.870Z\\",\\"updatedAt\\":\\"2023-06-16T19:27:14.862Z\\",\\"variations\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f40\\",\\"key\\":\\"yo\\",\\"name\\":\\"Yo\\",\\"variables\\":{\\"new-variable\\":false,\\"first-feature\\":true}},{\\"_id\\":\\"63b5eea3e6e91987bae47f41\\",\\"key\\":\\"variation-a\\",\\"name\\":\\"Variation A\\",\\"variables\\":{}},{\\"_id\\":\\"63b5eea3e6e91987bae47f42\\",\\"key\\":\\"variation-b\\",\\"name\\":\\"Variation B\\",\\"variables\\":{}}],\\"controlVariation\\":\\"control\\",\\"variables\\":[{\\"_id\\":\\"63b5eea3e6e91987bae47f3c\\",\\"_project\\":\\"63b5ee5de6e91987bae47f01\\",\\"_feature\\":\\"63b5eea3e6e91987bae47f3a\\",\\"name\\":\\"first-feature\\",\\"key\\":\\"first-feature\\",\\"type\\":\\"Boolean\\",\\"status\\":\\"active\\",\\"defaultValue\\":false,\\"source\\":\\"dashboard\\",\\"_createdBy\\":\\"google-oauth2|111559006563333334214\\",\\"createdAt\\":\\"2023-01-04T21:24:51.877Z\\",\\"updatedAt\\":\\"2023-01-04T21:24:51.877Z\\"}],\\"tags\\":[],\\"readonly\\":false,\\"settings\\":{\\"optInEnabled\\":false,\\"publicName\\":\\"\\",\\"publicDescription\\":\\"\\"},\\"sdkVisibility\\":{\\"client\\":false,\\"mobile\\":false,\\"server\\":true}}
 "
 `;
 
@@ -107,6 +108,7 @@ exports[`variations update updates a variation and returns the full feature in i
   \\"source\\": \\"dashboard\\",
   \\"type\\": \\"experiment\\",
   \\"name\\": \\"First Feature\\",
+  \\"key\\": \\"first-feature\\",
   \\"description\\": \\"\\",
   \\"_createdBy\\": \\"google-oauth2|111559006563333334214\\",
   \\"createdAt\\": \\"2023-01-04T21:24:51.870Z\\",

--- a/src/commands/variations/create.test.ts
+++ b/src/commands/variations/create.test.ts
@@ -62,6 +62,7 @@ describe('variations create', () => {
         type: 'experiment',
         name: 'First Feature',
         description: '',
+        key: 'first-feature',
         _createdBy: 'google-oauth2|111559006563333334214',
         createdAt: '2023-01-04T21:24:51.870Z',
         updatedAt: '2023-06-16T19:27:14.862Z',
@@ -189,7 +190,7 @@ describe('variations create', () => {
         )
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${featureKey}`)
+                .get(`/v2/projects/${projectKey}/features/${featureKey}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>

--- a/src/commands/variations/update.test.ts
+++ b/src/commands/variations/update.test.ts
@@ -70,6 +70,7 @@ describe('variations update', () => {
         source: 'dashboard',
         type: 'experiment',
         name: 'First Feature',
+        key: 'first-feature',
         description: '',
         _createdBy: 'google-oauth2|111559006563333334214',
         createdAt: '2023-01-04T21:24:51.870Z',
@@ -137,7 +138,7 @@ describe('variations update', () => {
         )
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${featureKey}`)
+                .get(`/v2/projects/${projectKey}/features/${featureKey}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>
@@ -188,7 +189,7 @@ describe('variations update', () => {
         )
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${featureKey}`)
+                .get(`/v2/projects/${projectKey}/features/${featureKey}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>
@@ -238,7 +239,7 @@ describe('variations update', () => {
         )
         .nock(BASE_URL, (api) =>
             api
-                .get(`/v1/projects/${projectKey}/features/${featureKey}`)
+                .get(`/v2/projects/${projectKey}/features/${featureKey}`)
                 .reply(200, mockFeature),
         )
         .nock(BASE_URL, (api) =>

--- a/src/utils/features/quickCreateFeatureUtils.ts
+++ b/src/utils/features/quickCreateFeatureUtils.ts
@@ -1,6 +1,4 @@
-import { fetchEnvironments } from '../../api/environments'
 import { CreateFeatureParams } from '../../api/schemas'
-import { updateFeatureConfigForEnvironment } from '../../api/targeting'
 
 // Default variations and variables depending on the key and name provided for quick create
 export const mergeQuickFeatureParamsWithAnswers = (
@@ -110,52 +108,3 @@ export const getQuickConfigurations =
             },
         }
     }
-
-// Setup targeting for all environments and turn on development only
-export const setupTargetingForEnvironments = async (
-    authToken: string,
-    projectKey: string,
-    featureKey: string,
-) => {
-    const environments = await fetchEnvironments(authToken, projectKey)
-    await Promise.all(
-        environments.map((environment) =>
-            updateFeatureConfigForEnvironment(
-                authToken,
-                projectKey,
-                featureKey,
-                environment.key,
-                {
-                    targets:
-                        environment.type !== 'development'
-                            ? []
-                            : [
-                                  {
-                                      distribution: [
-                                          {
-                                              percentage: 1,
-                                              _variation: 'variation-on',
-                                          },
-                                      ],
-                                      audience: {
-                                          name: 'All Users',
-                                          filters: {
-                                              filters: [
-                                                  {
-                                                      type: 'all',
-                                                  },
-                                              ],
-                                              operator: 'and',
-                                          },
-                                      },
-                                  },
-                              ],
-                    status:
-                        environment.type === 'development'
-                            ? 'active'
-                            : 'inactive',
-                },
-            ),
-        ),
-    )
-}

--- a/src/utils/features/quickCreateFeatureUtils.ts
+++ b/src/utils/features/quickCreateFeatureUtils.ts
@@ -17,6 +17,7 @@ export const mergeQuickFeatureParamsWithAnswers = (
                 type: 'Boolean',
             },
         ],
+        configurations: getQuickConfigurations(),
         variations: [
             {
                 key: 'variation-on',
@@ -31,6 +32,84 @@ export const mergeQuickFeatureParamsWithAnswers = (
         ],
     }
 }
+
+export const getQuickConfigurations =
+    (): CreateFeatureParams['configurations'] => {
+        return {
+            development: {
+                targets: [
+                    {
+                        distribution: [
+                            {
+                                percentage: 1,
+                                _variation: 'variation-on',
+                            },
+                        ],
+                        audience: {
+                            name: 'All Users',
+                            filters: {
+                                filters: [
+                                    {
+                                        type: 'all',
+                                    },
+                                ],
+                                operator: 'and',
+                            },
+                        },
+                    },
+                ],
+                status: 'active',
+            },
+            staging: {
+                targets: [
+                    {
+                        distribution: [
+                            {
+                                percentage: 1,
+                                _variation: 'variation-on',
+                            },
+                        ],
+                        audience: {
+                            name: 'All Users',
+                            filters: {
+                                filters: [
+                                    {
+                                        type: 'all',
+                                    },
+                                ],
+                                operator: 'and',
+                            },
+                        },
+                    },
+                ],
+                status: 'active',
+            },
+            production: {
+                targets: [
+                    {
+                        distribution: [
+                            {
+                                percentage: 1,
+                                _variation: 'variation-on',
+                            },
+                        ],
+                        audience: {
+                            name: 'All Users',
+                            filters: {
+                                filters: [
+                                    {
+                                        type: 'all',
+                                    },
+                                ],
+                                operator: 'and',
+                            },
+                        },
+                    },
+                ],
+                status: 'active',
+            },
+        }
+    }
 
 // Setup targeting for all environments and turn on development only
 export const setupTargetingForEnvironments = async (

--- a/src/utils/features/quickCreateFeatureUtils.ts
+++ b/src/utils/features/quickCreateFeatureUtils.ts
@@ -82,7 +82,7 @@ export const getQuickConfigurations =
                         },
                     },
                 ],
-                status: 'active',
+                status: 'inactive',
             },
             production: {
                 targets: [
@@ -106,7 +106,7 @@ export const getQuickConfigurations =
                         },
                     },
                 ],
-                status: 'active',
+                status: 'inactive',
             },
         }
     }

--- a/test-utils/dvcTest.ts
+++ b/test-utils/dvcTest.ts
@@ -37,7 +37,7 @@ export const mockFeatures = [
         variations: [],
         variables: [],
         tags: [],
-        configurations: {},
+        configurations: [],
         sdkVisibility: {
             mobile: true,
             client: true,
@@ -59,7 +59,7 @@ export const mockFeatures = [
         variations: [],
         variables: [],
         tags: [],
-        configurations: {},
+        configurations: [],
         sdkVisibility: {
             mobile: true,
             client: true,

--- a/test-utils/dvcTest.ts
+++ b/test-utils/dvcTest.ts
@@ -23,3 +23,50 @@ export const dvcTest = () =>
                 },
             ])
         })
+
+export const mockFeatures = [
+    {
+        key: 'feature-1',
+        name: 'Feature 1',
+        _id: '61450f3daec96f5cf4a49946',
+        _project: 'test-project',
+        source: 'api',
+        _createdBy: 'test-user',
+        createdAt: '2021-09-15T12:00:00Z',
+        updatedAt: '2021-09-15T12:00:00Z',
+        variations: [],
+        variables: [],
+        tags: [],
+        configurations: {},
+        sdkVisibility: {
+            mobile: true,
+            client: true,
+            server: true,
+        },
+        settings: {},
+        readonly: false,
+        controlVariation: 'control',
+    },
+    {
+        key: 'feature-2',
+        name: 'Feature 2',
+        _id: '61450f3daec96f5cf4a49947',
+        _project: 'test-project',
+        source: 'api',
+        _createdBy: 'test-user',
+        createdAt: '2021-09-15T12:00:00Z',
+        updatedAt: '2021-09-15T12:00:00Z',
+        variations: [],
+        variables: [],
+        tags: [],
+        configurations: {},
+        sdkVisibility: {
+            mobile: true,
+            client: true,
+            server: true,
+        },
+        settings: {},
+        readonly: false,
+        controlVariation: 'control',
+    },
+]


### PR DESCRIPTION
# Changes

- Update the CLI to use the v2 Features endpoint for most uses,
- kept variations until those are implemented in v2

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
