### PR TITLE
add deprecation notices to type generator output when feature is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g @devcycle/cli
 $ dvc COMMAND
 running command...
 $ dvc (--version)
-@devcycle/cli/5.16.2 linux-x64 node-v20.10.0
+@devcycle/cli/5.16.2 darwin-arm64 node-v20.10.0
 $ dvc --help [COMMAND]
 USAGE
   $ dvc COMMAND

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -13,17 +13,17 @@ Generate Variable Types from the management API
 USAGE
   $ dvc generate types [--config-path <value>] [--auth-path <value>] [--repo-config-path <value>] [--client-id
     <value>] [--client-secret <value>] [--project <value>] [--no-api] [--headless] [--output-dir <value>] [--react]
-    [--nextjs] [--old-repos] [--inline-comments] [--include-descriptions] [--obfuscate]
+    [--nextjs] [--old-repos] [--include-descriptions] [--obfuscate] [--include-deprecation-warnings]
 
 FLAGS
-  --include-descriptions  Include variable descriptions in the variable information comment
-  --inline-comments       Inline variable informaton comment on the same line as the type definition
-  --nextjs                Generate types for use with Next.js
-  --obfuscate             Obfuscate the variable keys.
-  --old-repos             Generate types for use with old DevCycle repos (@devcycle/devcycle-react-sdk,
-                          @devcycle/devcycle-js-sdk)
-  --output-dir=<value>    [default: .] Directory to output the generated types to
-  --react                 Generate types for use with React
+  --include-deprecation-warnings  Include @deprecated tags for variables of completed features
+  --include-descriptions          Include variable descriptions in the variable information comment
+  --nextjs                        Generate types for use with Next.js
+  --obfuscate                     Obfuscate the variable keys.
+  --old-repos                     Generate types for use with old DevCycle repos (@devcycle/devcycle-react-sdk,
+                                  @devcycle/devcycle-js-sdk)
+  --output-dir=<value>            [default: .] Directory to output the generated types to
+  --react                         Generate types for use with React
 
 GLOBAL FLAGS
   --auth-path=<value>         Override the default location to look for an auth.yml file

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.16.1",
+  "version": "5.16.2",
   "commands": {
     "authCommand": {
       "id": "authCommand",
@@ -2236,6 +2236,7 @@
           "name": "inline-comments",
           "type": "boolean",
           "description": "Inline variable informaton comment on the same line as the type definition",
+          "hidden": true,
           "allowNo": false
         },
         "include-descriptions": {
@@ -2248,6 +2249,12 @@
           "name": "obfuscate",
           "type": "boolean",
           "description": "Obfuscate the variable keys.",
+          "allowNo": false
+        },
+        "include-deprecation-warnings": {
+          "name": "include-deprecation-warnings",
+          "type": "boolean",
+          "description": "Include @deprecated tags for variables of completed features",
           "allowNo": false
         }
       },

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
         "prepack": "yarn build && oclif manifest && oclif readme --multi",
         "test": "mocha test/*.ts \"src/**/*.test.ts\"",
         "test:ci": "yarn test --forbid-only",
+        "test:update-snapshots": "UPDATE_SNAPSHOT=1 yarn test",
         "version": "oclif readme --multi && git add README.md"
     },
     "engines": {

--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -335,6 +335,7 @@ const Variable = z.object({
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
     validationSchema: VariableValidationEntity.optional(),
+    persistent: z.boolean().optional(),
 })
 const UpdateVariableDto = z
     .object({
@@ -452,6 +453,7 @@ const Feature = z.object({
         'cli',
     ]),
     type: z.enum(['release', 'experiment', 'permission', 'ops']).optional(),
+    status: z.enum(['active', 'complete', 'archived']).optional(),
     _createdBy: z.string().optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),

--- a/src/commands/generate/__snapshots__/types.test.ts.snap
+++ b/src/commands/generate/__snapshots__/types.test.ts.snap
@@ -5,125 +5,110 @@ exports[`generate types correctly generates JS SDK types 1`] = `
 
 export type DVCVariableTypes = {
     /**
-        description: Different ways to say hello
-        created by: User 1
-        created on: 2021-07-04
+     * key: enum-var
+     * description: Different ways to say hello
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'enum-var': 'Hello' | 'Hey' | 'Hi'
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: regex-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'regex-var': string
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: string-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'string-var': string
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: boolean-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'boolean-var': boolean
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: number-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'number-var': number
     /**
-        created by: Unknown User
-        created on: 2021-07-04
+     * key: json-var
+     * created by: Unknown User
+     * created on: 2021-07-04
     */
     'json-var': DevCycleJSON
+    /**
+     * key: deprecated-var
+     * created by: Unknown User
+     * created on: 2021-07-04
+     * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+    */
+    'deprecated-var': string
 }
 
 /**
-    description: Different ways to say hello
-    created by: User 1
-    created on: 2021-07-04
+ * key: enum-var
+ * description: Different ways to say hello
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const ENUM_VAR = 'enum-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: regex-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const REGEX_VAR = 'regex-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: string-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const STRING_VAR = 'string-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: boolean-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const BOOLEAN_VAR = 'boolean-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: number-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const NUMBER_VAR = 'number-var' as const
 
 /**
-    created by: Unknown User
-    created on: 2021-07-04
+ * key: json-var
+ * created by: Unknown User
+ * created on: 2021-07-04
 */
+
 export const JSON_VAR = 'json-var' as const
-"
-`;
-
-exports[`generate types correctly generates JS SDK types with inlined comments 1`] = `
-"import { DevCycleJSON } from '@devcycle/js-client-sdk'
-
-export type DVCVariableTypes = {
-    'enum-var': 'Hello' | 'Hey' | 'Hi' // (Different ways to say hello) created by User 1 on 2021-07-04
-    'regex-var': string // created by User 2 on 2021-07-04
-    'string-var': string // created by User 1 on 2021-07-04
-    'boolean-var': boolean // created by User 2 on 2021-07-04
-    'number-var': number // created by User 1 on 2021-07-04
-    'json-var': DevCycleJSON // created by Unknown User on 2021-07-04
-}
 
 /**
-    description: Different ways to say hello
-    created by: User 1
-    created on: 2021-07-04
-*/
-export const ENUM_VAR = 'enum-var' as const
+ * key: deprecated-var
+ * created by: Unknown User
+ * created on: 2021-07-04
+ * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
 
-/**
-    created by: User 2
-    created on: 2021-07-04
 */
-export const REGEX_VAR = 'regex-var' as const
 
-/**
-    created by: User 1
-    created on: 2021-07-04
-*/
-export const STRING_VAR = 'string-var' as const
-
-/**
-    created by: User 2
-    created on: 2021-07-04
-*/
-export const BOOLEAN_VAR = 'boolean-var' as const
-
-/**
-    created by: User 1
-    created on: 2021-07-04
-*/
-export const NUMBER_VAR = 'number-var' as const
-
-/**
-    created by: Unknown User
-    created on: 2021-07-04
-*/
-export const JSON_VAR = 'json-var' as const
+export const DEPRECATED_VAR = 'deprecated-var' as const
 "
 `;
 
@@ -137,50 +122,60 @@ export type DVCVariableTypes = {
     'dvc_obfs_9d44428272a4f0f8fefd891d93f0268ca3e52464ca95147d077437ba82318700': boolean
     'dvc_obfs_f66155be75be4dc7e53cc13a7837db8b389be45c8bd65653e384f7afaddba1d7': number
     'dvc_obfs_a991871dbce45b30da1e125ae28b59eb74c1da1f48ad6a2112ac5395093f37f0': DevCycleJSON
+    'dvc_obfs_a991871dbce45b30da1e125ae28b59eb74c1da1f48ad6a2112ac5395093f37f0': string
 }
 
 /**
-    key: enum-var
-    description: Different ways to say hello
-    created by: User 1
-    created on: 2021-07-04
+ * description: Different ways to say hello
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const ENUM_VAR = 'dvc_obfs_8397a7cc0bd9847dab4cfcffc90d01385e21fec6f1d3999e3aaac2a137d69964' as const
 
 /**
-    key: regex-var
-    created by: User 2
-    created on: 2021-07-04
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const REGEX_VAR = 'dvc_obfs_cabd691e35fffe317483d72108898be69e03c7611dfb035660e4f71b9ed8cc44' as const
 
 /**
-    key: string-var
-    created by: User 1
-    created on: 2021-07-04
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const STRING_VAR = 'dvc_obfs_ceb6db49d7e9c00eb307304a7a23f2c404777030a4324bf34ce50ed7148a4e79' as const
 
 /**
-    key: boolean-var
-    created by: User 2
-    created on: 2021-07-04
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const BOOLEAN_VAR = 'dvc_obfs_9d44428272a4f0f8fefd891d93f0268ca3e52464ca95147d077437ba82318700' as const
 
 /**
-    key: number-var
-    created by: User 1
-    created on: 2021-07-04
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const NUMBER_VAR = 'dvc_obfs_f66155be75be4dc7e53cc13a7837db8b389be45c8bd65653e384f7afaddba1d7' as const
 
 /**
-    key: json-var
-    created by: Unknown User
-    created on: 2021-07-04
+ * created by: Unknown User
+ * created on: 2021-07-04
 */
+
 export const JSON_VAR = 'dvc_obfs_a991871dbce45b30da1e125ae28b59eb74c1da1f48ad6a2112ac5395093f37f0' as const
+
+/**
+ * created by: Unknown User
+ * created on: 2021-07-04
+ * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+*/
+
+export const DEPRECATED_VAR = 'dvc_obfs_a991871dbce45b30da1e125ae28b59eb74c1da1f48ad6a2112ac5395093f37f0' as const
 "
 `;
 
@@ -215,74 +210,110 @@ export const useVariable = originalUseVariable as UseVariable
 
 export type DVCVariableTypes = {
     /**
-        description: Different ways to say hello
-        created by: User 1
-        created on: 2021-07-04
+     * key: enum-var
+     * description: Different ways to say hello
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'enum-var': 'Hello' | 'Hey' | 'Hi'
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: regex-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'regex-var': string
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: string-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'string-var': string
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: boolean-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'boolean-var': boolean
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: number-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'number-var': number
     /**
-        created by: Unknown User
-        created on: 2021-07-04
+     * key: json-var
+     * created by: Unknown User
+     * created on: 2021-07-04
     */
     'json-var': DevCycleJSON
+    /**
+     * key: deprecated-var
+     * created by: Unknown User
+     * created on: 2021-07-04
+     * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+    */
+    'deprecated-var': string
 }
 
 /**
-    description: Different ways to say hello
-    created by: User 1
-    created on: 2021-07-04
+ * key: enum-var
+ * description: Different ways to say hello
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const ENUM_VAR = 'enum-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: regex-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const REGEX_VAR = 'regex-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: string-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const STRING_VAR = 'string-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: boolean-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const BOOLEAN_VAR = 'boolean-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: number-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const NUMBER_VAR = 'number-var' as const
 
 /**
-    created by: Unknown User
-    created on: 2021-07-04
+ * key: json-var
+ * created by: Unknown User
+ * created on: 2021-07-04
 */
+
 export const JSON_VAR = 'json-var' as const
+
+/**
+ * key: deprecated-var
+ * created by: Unknown User
+ * created on: 2021-07-04
+ * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+*/
+
+export const DEPRECATED_VAR = 'deprecated-var' as const
 "
 `;
 
@@ -317,73 +348,109 @@ export const useVariable = originalUseVariable as UseVariable
 
 export type DVCVariableTypes = {
     /**
-        description: Different ways to say hello
-        created by: User 1
-        created on: 2021-07-04
+     * key: enum-var
+     * description: Different ways to say hello
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'enum-var': 'Hello' | 'Hey' | 'Hi'
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: regex-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'regex-var': string
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: string-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'string-var': string
     /**
-        created by: User 2
-        created on: 2021-07-04
+     * key: boolean-var
+     * created by: User 2
+     * created on: 2021-07-04
     */
     'boolean-var': boolean
     /**
-        created by: User 1
-        created on: 2021-07-04
+     * key: number-var
+     * created by: User 1
+     * created on: 2021-07-04
     */
     'number-var': number
     /**
-        created by: Unknown User
-        created on: 2021-07-04
+     * key: json-var
+     * created by: Unknown User
+     * created on: 2021-07-04
     */
     'json-var': DevCycleJSON
+    /**
+     * key: deprecated-var
+     * created by: Unknown User
+     * created on: 2021-07-04
+     * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+    */
+    'deprecated-var': string
 }
 
 /**
-    description: Different ways to say hello
-    created by: User 1
-    created on: 2021-07-04
+ * key: enum-var
+ * description: Different ways to say hello
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const ENUM_VAR = 'enum-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: regex-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const REGEX_VAR = 'regex-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: string-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const STRING_VAR = 'string-var' as const
 
 /**
-    created by: User 2
-    created on: 2021-07-04
+ * key: boolean-var
+ * created by: User 2
+ * created on: 2021-07-04
 */
+
 export const BOOLEAN_VAR = 'boolean-var' as const
 
 /**
-    created by: User 1
-    created on: 2021-07-04
+ * key: number-var
+ * created by: User 1
+ * created on: 2021-07-04
 */
+
 export const NUMBER_VAR = 'number-var' as const
 
 /**
-    created by: Unknown User
-    created on: 2021-07-04
+ * key: json-var
+ * created by: Unknown User
+ * created on: 2021-07-04
 */
+
 export const JSON_VAR = 'json-var' as const
+
+/**
+ * key: deprecated-var
+ * created by: Unknown User
+ * created on: 2021-07-04
+ * @deprecated This variable is part of complete feature \\"Completed Feature\\" and should be cleaned up.
+
+*/
+
+export const DEPRECATED_VAR = 'deprecated-var' as const
 "
 `;

--- a/src/commands/generate/types.ts
+++ b/src/commands/generate/types.ts
@@ -114,7 +114,6 @@ export default class GenerateTypes extends Base {
     methodNames: Record<string, string[]> = {}
     orgMembers: OrganizationMember[]
     includeDescriptions = false
-    inlineComments = false // This will always be false now
     obfuscate = false
     project: Project
     outputDir: string


### PR DESCRIPTION
- check if each variable is part of a completed or archived feature and is not marked permanent
- if all of that is true, add a deprecation notice to the variable and its constant alias
- remove option for inline comments because it's not really that useful and requires maintaining two different code paths for comment generation, plus deprecation warnings dont work in that format
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/b96d523a-e949-4642-9039-3665c6f92221">
