### PR TITLE
fix deprecation notice for type generator flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g @devcycle/cli
 $ dvc COMMAND
 running command...
 $ dvc (--version)
-@devcycle/cli/5.20.0 linux-x64 node-v20.10.0
+@devcycle/cli/5.20.0 darwin-arm64 node-v20.10.0
 $ dvc --help [COMMAND]
 USAGE
   $ dvc COMMAND

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.19.0",
+  "version": "5.20.0",
   "commands": {
     "authCommand": {
       "id": "authCommand",

--- a/src/commands/generate/types.ts
+++ b/src/commands/generate/types.ts
@@ -79,7 +79,6 @@ export default class GenerateTypes extends Base {
         }),
         react: Flags.boolean({
             description: 'Generate types for use with React',
-            default: false,
             deprecated: {
                 message:
                     'The React SDK since v1.30.0 does not require this flag. Its types can be augmented automatically',
@@ -87,7 +86,6 @@ export default class GenerateTypes extends Base {
         }),
         nextjs: Flags.boolean({
             description: 'Generate types for use with Next.js',
-            default: false,
             deprecated: {
                 message:
                     'The Next.js SDK since v2.7.0 does not require this flag. Its types can be augmented automatically',


### PR DESCRIPTION
- apparently oclif will print deprecation warnings for a flag that isn't specified if it has a default value defined
- feels like a bug in oclif, but just removing the default value for now to fix it.