### PR TITLE
fix: add support for customData targeting filters with boolean, number or string values

### DIFF
--- a/src/api/zodClient.ts
+++ b/src/api/zodClient.ts
@@ -218,7 +218,7 @@ const UserCustomFilter = z.object({
     ]),
     dataKey: z.string().min(1),
     dataKeyType: z.enum(['String', 'Boolean', 'Number']),
-    values: z.object({}).partial().optional(),
+    values: z.array(z.union([z.boolean(), z.string(), z.number()])).optional(),
     type: z.literal('user').default('user'),
     subType: z.literal('customData').default('customData'),
 })

--- a/src/commands/targeting/__snapshots__/update.test.ts.snap
+++ b/src/commands/targeting/__snapshots__/update.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`targeting update update a target in headless mode with a custom data key 1`] = `
+"{\\"_feature\\":\\"647e36gg16d9k4815fi3f97d\\",\\"_environment\\":\\"648b421gg3f682869c0f22f8\\",\\"_createdBy\\":\\"test\\",\\"status\\":\\"inactive\\",\\"updatedAt\\":\\"2023-06-27T03:19:58.541Z\\",\\"targets\\":[{\\"distribution\\":[{\\"_variation\\":\\"variation-on\\",\\"percentage\\":1}],\\"audience\\":{\\"name\\":\\"Shrek Fans\\",\\"filters\\":{\\"filters\\":[{\\"type\\":\\"user\\",\\"subType\\":\\"customData\\",\\"comparator\\":\\"=\\",\\"values\\":[true],\\"dataKey\\":\\"isShrek\\",\\"dataKeyType\\":\\"Boolean\\"}],\\"operator\\":\\"and\\"}}}]}
+"
+`;
+
 exports[`targeting update updates a target by adding a filter in interactive mode 1`] = `
 "
 

--- a/src/commands/targeting/update.test.ts
+++ b/src/commands/targeting/update.test.ts
@@ -222,9 +222,9 @@ describe('targeting update', () => {
         ...mockResponseInteractive,
         targets: [
             {
-                ...mockResponseInteractive.targets[0],
+                ...customDataRequestBody.targets[0],
                 audience: {
-                    ...mockResponseInteractive.targets[0].audience,
+                    ...customDataRequestBody.targets[0].audience,
                 },
             },
         ],
@@ -387,14 +387,6 @@ describe('targeting update', () => {
                 .reply(200, mockVariations),
         )
         .nock(BASE_URL, (api) =>
-            api
-                .get(
-                    `/v1/projects/${projectKey}/features/${featureKey}/configurations`,
-                )
-                .query({ environment: envKey })
-                .reply(200, mockTargetingRules),
-        )
-        .nock(BASE_URL, (api) =>
             api.get(`/v1/projects/${projectKey}/audiences`).reply(200, []),
         )
         .nock(BASE_URL, (api) =>
@@ -406,7 +398,7 @@ describe('targeting update', () => {
                 .query({ environment: envKey })
                 .reply(200, mockResponseCustomData),
         )
-        .stderr()
+        .stdout()
         .command([
             'targeting update',
             featureKey,
@@ -419,9 +411,9 @@ describe('targeting update', () => {
             '[{ "name": "Shrek Fans", "serve": "variation-on", "definition": [{ "type": "user", "subType": "customData", "comparator": "=", "values": [true], "dataKey": "isShrek", "dataKeyType": "Boolean" }] }]',
         ])
         .it(
-            'fails to update a target in headless mode with a custom data key',
+            'update a target in headless mode with a custom data key',
             (ctx) => {
-                expect(ctx.stderr).contains('Expected string, received boolean')
+                expect(ctx.stdout).toMatchSnapshot()
             },
         )
 })

--- a/src/commands/targeting/update.test.ts
+++ b/src/commands/targeting/update.test.ts
@@ -189,6 +189,47 @@ describe('targeting update', () => {
         ],
     }
 
+    const customDataRequestBody = {
+        targets: [
+            {
+                distribution: [
+                    {
+                        _variation: 'variation-on',
+                        percentage: 1,
+                    },
+                ],
+                audience: {
+                    name: 'Shrek Fans',
+                    filters: {
+                        filters: [
+                            {
+                                type: 'user',
+                                subType: 'customData',
+                                comparator: '=',
+                                values: [true],
+                                dataKey: 'isShrek',
+                                dataKeyType: 'Boolean',
+                            },
+                        ],
+                        operator: 'and',
+                    },
+                },
+            },
+        ],
+    }
+
+    const mockResponseCustomData = {
+        ...mockResponseInteractive,
+        targets: [
+            {
+                ...mockResponseInteractive.targets[0],
+                audience: {
+                    ...mockResponseInteractive.targets[0].audience,
+                },
+            },
+        ],
+    }
+
     dvcTest()
         .nock(BASE_URL, (api) =>
             api
@@ -329,6 +370,58 @@ describe('targeting update', () => {
             'updates a target by adding a filter in interactive mode',
             (ctx) => {
                 expect(ctx.stdout).toMatchSnapshot()
+            },
+        )
+
+    dvcTest()
+        .nock(BASE_URL, (api) =>
+            api
+                .get(`/v1/projects/${projectKey}/environments/${envKey}`)
+                .reply(200, mockEnvironment),
+        )
+        .nock(BASE_URL, (api) =>
+            api
+                .get(
+                    `/v1/projects/${projectKey}/features/${featureKey}/variations`,
+                )
+                .reply(200, mockVariations),
+        )
+        .nock(BASE_URL, (api) =>
+            api
+                .get(
+                    `/v1/projects/${projectKey}/features/${featureKey}/configurations`,
+                )
+                .query({ environment: envKey })
+                .reply(200, mockTargetingRules),
+        )
+        .nock(BASE_URL, (api) =>
+            api.get(`/v1/projects/${projectKey}/audiences`).reply(200, []),
+        )
+        .nock(BASE_URL, (api) =>
+            api
+                .patch(
+                    `/v1/projects/${projectKey}/features/${featureKey}/configurations`,
+                    customDataRequestBody,
+                )
+                .query({ environment: envKey })
+                .reply(200, mockResponseCustomData),
+        )
+        .stderr()
+        .command([
+            'targeting update',
+            featureKey,
+            envKey,
+            '--project',
+            projectKey,
+            ...authFlags,
+            '--headless',
+            '--targets',
+            '[{ "name": "Shrek Fans", "serve": "variation-on", "definition": [{ "type": "user", "subType": "customData", "comparator": "=", "values": [true], "dataKey": "isShrek", "dataKeyType": "Boolean" }] }]',
+        ])
+        .it(
+            'fails to update a target in headless mode with a custom data key',
+            (ctx) => {
+                expect(ctx.stderr).contains('Expected string, received boolean')
             },
         )
 })

--- a/src/ui/targetingTree.ts
+++ b/src/ui/targetingTree.ts
@@ -150,7 +150,9 @@ const buildDefinitionTree = (
                 Array.isArray(filter.values) &&
                 !['exist', '!exist'].includes(filter.subType)
             ) {
-                filter.values.forEach((value) => values.insert(value))
+                filter.values.forEach((value) =>
+                    values.insert(value.toString()),
+                )
             }
             userFilter.insert(comparatorMap[filter.comparator], values)
             const userProperty =


### PR DESCRIPTION
- chore: add failing test for failing custom data targeting filter
- feat: add support for boolean, number and string values on a Target Definition with  `"subType": "customData"`