### PR TITLE
chore: Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Unit Tests
 on:
   pull_request
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/cli/security/code-scanning/11](https://github.com/DevCycleHQ/cli/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow is a basic CI pipeline that checks out the code, installs dependencies, builds the project, and runs tests, it only requires `contents: read` permissions. This ensures that the workflow has the least privileges necessary to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
