### PR TITLE
Chore: pin action to specific commit

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -107,7 +107,7 @@ jobs:
 
       # Move this to release action yml once it works the first time
       - name: Update Homebrew Formula
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/homebrew-cli


### PR DESCRIPTION
# Pin repository-dispatch action to specific commit

## Summary
Pins the `peter-evans/repository-dispatch` action from `v2` tag to commit `bf47d102fdb849e755b0b0023ea3e81a44b6f570` to address CodeQL security alert.

## Changes
- Updated `.github/workflows/cli-release.yml` to use pinned commit hash instead of mutable tag