### PR TITLE
feat(FDN-547): Add API request headers for MCP server tracking

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -12,7 +12,7 @@ export const setDVCReferrer = (
     version: string,
     caller = 'cli',
 ): void => {
-    axiosClient.defaults.headers.common['dvc-referrer'] = 'cli'
+    axiosClient.defaults.headers.common['dvc-referrer'] = caller
 
     // Ensure we have valid values before stringifying
     const metadata = {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { DevCycleMCPServer } from './server'
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { setMCPHeaders } from './utils/headers'
 
 // Get version for MCP server
 function getVersion(): string {
@@ -46,10 +47,16 @@ if (args.includes('--help') || args.includes('-h')) {
 }
 
 async function main() {
+    const version = getVersion()
+
+    // Set up MCP-specific headers for all API requests
+    // This ensures that requests from the MCP server are properly identified
+    setMCPHeaders(version)
+
     const server = new Server(
         {
             name: 'devcycle',
-            version: getVersion(),
+            version,
         },
         {
             capabilities: {

--- a/src/mcp/utils/api.ts
+++ b/src/mcp/utils/api.ts
@@ -1,4 +1,5 @@
 import { DevCycleAuth } from './auth'
+import { setMCPToolCommand } from './headers'
 
 function getErrorMessage(error: unknown): string {
     if (error instanceof Error && error.message) {
@@ -48,6 +49,9 @@ export class DevCycleApiClient {
             if (requiresProject) {
                 this.auth.requireProject()
             }
+
+            // Set the specific MCP tool command in headers before making API calls
+            setMCPToolCommand(operationName)
 
             const authToken = this.auth.getAuthToken()
             const projectKey = requiresProject ? this.auth.getProjectKey() : ''

--- a/src/mcp/utils/headers.ts
+++ b/src/mcp/utils/headers.ts
@@ -1,0 +1,29 @@
+import { setDVCReferrer } from '../../api/apiClient'
+
+// Store the version for reuse in tool commands
+let mcpVersion: string = 'unknown'
+
+/**
+ * Sets up MCP-specific headers for all API requests
+ * This ensures that API calls made from the MCP server are properly identified
+ * and can be tracked separately from CLI commands
+ */
+export function setMCPHeaders(version: string): void {
+    // Store version for later use in tool commands
+    mcpVersion = version
+
+    // Set the referrer to identify this as an MCP request
+    // Command will be set dynamically for each tool call
+    // Caller is 'mcp' to distinguish from 'cli' and other callers
+    setDVCReferrer('mcp', version, 'mcp')
+}
+
+/**
+ * Updates the command in the headers for a specific MCP tool call
+ * This allows tracking of individual MCP operations (e.g., "list_features", "create_project")
+ * @param toolName - The name of the MCP tool being called
+ */
+export function setMCPToolCommand(toolName: string): void {
+    // Update the command to be the tool name, keeping version and caller the same
+    setDVCReferrer(toolName, mcpVersion, 'mcp')
+}


### PR DESCRIPTION
## feat: Add API request headers for MCP server tracking

### Solution
- Added MCP-specific headers to all API requests made through the MCP server
- Dynamically set the `command` field to the specific MCP tool name (e.g., "list_features", "create_project")
- Fixed bug in `setDVCReferrer` where `caller` parameter was ignored

### Changes
- **New**: `src/mcp/utils/headers.ts` - Utilities for setting MCP headers
- **Updated**: `src/mcp/index.ts` - Initialize headers on server startup
- **Updated**: `src/mcp/utils/api.ts` - Set tool-specific command before each API call
- **Fixed**: `src/api/apiClient.ts` - Use `caller` parameter instead of hardcoded 'cli'

### Result
API requests now include proper identification:
- **CLI requests**: `{"command":"<cli_command>","caller":"cli","version":"<version>"}`
- **MCP requests**: `{"command":"<mcp_tool>","caller":"mcp","version":"<version>"}`

This enables better analytics, debugging, and tracking of MCP tool usage patterns.