### PR TITLE
test: Add Minimal MCP API Client Tests

### DIFF
--- a/src/mcp/utils/api.test.ts
+++ b/src/mcp/utils/api.test.ts
@@ -1,0 +1,174 @@
+import { expect } from '@oclif/test'
+import sinon from 'sinon'
+import * as assert from 'assert'
+import { DevCycleApiClient, handleZodiosValidationErrors } from './api'
+import { DevCycleAuth } from './auth'
+import { setMCPToolCommand } from './headers'
+import * as apiClientModule from '../../api/apiClient'
+
+describe('DevCycleApiClient', () => {
+    let apiClient: DevCycleApiClient
+    let authStub: sinon.SinonStubbedInstance<DevCycleAuth>
+    let setDVCReferrerStub: sinon.SinonStub
+
+    beforeEach(() => {
+        // Create stubbed auth instance
+        authStub = sinon.createStubInstance(DevCycleAuth)
+        authStub.getAuthToken.returns('mock-auth-token')
+        authStub.getProjectKey.returns('test-project')
+        authStub.getOrgId.returns('test-org-id')
+
+        apiClient = new DevCycleApiClient(authStub)
+
+        // Stub the setDVCReferrer function from apiClient module
+        setDVCReferrerStub = sinon.stub(apiClientModule, 'setDVCReferrer')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('Zodios Error Handling', () => {
+        it('should extract data from Zodios validation errors with 200 OK response', async () => {
+            const mockResponseData = { id: '123', name: 'Test Feature' }
+
+            const zodiosError = new Error(
+                'Zodios: Invalid response - status: 200 OK',
+            )
+            ;(zodiosError as any).data = mockResponseData
+
+            const apiCall = sinon.stub().rejects(zodiosError)
+
+            const result = await handleZodiosValidationErrors(
+                apiCall,
+                'testOperation',
+            )
+
+            expect(result).to.deep.equal(mockResponseData)
+        })
+
+        it('should re-throw non-Zodios errors unchanged', async () => {
+            const networkError = new Error('Network timeout')
+            const apiCall = sinon.stub().rejects(networkError)
+
+            try {
+                await handleZodiosValidationErrors(apiCall, 'testOperation')
+                assert.fail('Expected function to throw')
+            } catch (error) {
+                expect(error).to.equal(networkError)
+            }
+        })
+    })
+
+    describe('executeWithLogging', () => {
+        it('should execute operation successfully with valid auth and project', async () => {
+            const mockResult = { id: '123', name: 'Test Feature' }
+            const mockOperation = sinon.stub().resolves(mockResult)
+
+            authStub.requireAuth.returns()
+            authStub.requireProject.returns()
+
+            const result = await apiClient.executeWithLogging(
+                'testOperation',
+                { key: 'test-key' },
+                mockOperation,
+            )
+
+            expect(result).to.deep.equal(mockResult)
+            sinon.assert.calledOnce(authStub.requireAuth)
+            sinon.assert.calledOnce(authStub.requireProject)
+            sinon.assert.calledWith(
+                mockOperation,
+                'mock-auth-token',
+                'test-project',
+            )
+            sinon.assert.calledWith(
+                setDVCReferrerStub,
+                'testOperation',
+                sinon.match.string,
+                'mcp',
+            )
+        })
+
+        it('should handle authentication errors gracefully', async () => {
+            const authError = new Error('Authentication failed')
+            authStub.requireAuth.throws(authError)
+
+            const mockOperation = sinon.stub().resolves({})
+
+            try {
+                await apiClient.executeWithLogging(
+                    'testOperation',
+                    null,
+                    mockOperation,
+                )
+                assert.fail('Expected function to throw')
+            } catch (error) {
+                expect((error as Error).message).to.equal(
+                    'Authentication failed',
+                )
+                sinon.assert.notCalled(mockOperation)
+            }
+        })
+    })
+
+    describe('executeWithDashboardLink', () => {
+        it('should generate dashboard links correctly', async () => {
+            const mockResult = { key: 'test-feature', name: 'Test Feature' }
+            const mockOperation = sinon.stub().resolves(mockResult)
+            const dashboardLinkGenerator = sinon
+                .stub()
+                .returns(
+                    'https://app.devcycle.com/o/test-org-id/p/test-project/features',
+                )
+
+            authStub.requireAuth.returns()
+            authStub.requireProject.returns()
+
+            const result = await apiClient.executeWithDashboardLink(
+                'createFeature',
+                { key: 'test-feature' },
+                mockOperation,
+                dashboardLinkGenerator,
+            )
+
+            expect(result).to.deep.equal({
+                result: mockResult,
+                dashboardLink:
+                    'https://app.devcycle.com/o/test-org-id/p/test-project/features',
+            })
+
+            sinon.assert.calledWith(
+                dashboardLinkGenerator,
+                'test-org-id',
+                'test-project',
+                mockResult,
+            )
+        })
+    })
+})
+
+describe('Header Management', () => {
+    let setDVCReferrerStub: sinon.SinonStub
+
+    beforeEach(() => {
+        setDVCReferrerStub = sinon.stub(apiClientModule, 'setDVCReferrer')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('setMCPToolCommand', () => {
+        it('should set MCP headers correctly for tool commands', () => {
+            setMCPToolCommand('list_features')
+
+            sinon.assert.calledWith(
+                setDVCReferrerStub,
+                'list_features',
+                sinon.match.string, // version
+                'mcp',
+            )
+        })
+    })
+})

--- a/src/mcp/utils/api.test.ts
+++ b/src/mcp/utils/api.test.ts
@@ -115,7 +115,9 @@ describe('DevCycleApiClient', () => {
                 )
                 assert.fail('Expected function to throw')
             } catch (error) {
-                expect((error as Error).message).to.equal('Authentication failed')
+                expect((error as Error).message).to.equal(
+                    'Authentication failed',
+                )
                 sinon.assert.notCalled(mockOperation)
             }
         })

--- a/src/mcp/utils/api.test.ts
+++ b/src/mcp/utils/api.test.ts
@@ -32,10 +32,21 @@ describe('DevCycleApiClient', () => {
         it('should extract data from Zodios validation errors with 200 OK response', async () => {
             const mockResponseData = { id: '123', name: 'Test Feature' }
 
-            const zodiosError = new Error(
+            // Create a proper mock Zodios error with data property
+            class ZodiosValidationError extends Error {
+                constructor(
+                    message: string,
+                    public data: any,
+                ) {
+                    super(message)
+                    this.name = 'ZodiosValidationError'
+                }
+            }
+
+            const zodiosError = new ZodiosValidationError(
                 'Zodios: Invalid response - status: 200 OK',
+                mockResponseData,
             )
-            ;(zodiosError as any).data = mockResponseData
 
             const apiCall = sinon.stub().rejects(zodiosError)
 
@@ -104,9 +115,7 @@ describe('DevCycleApiClient', () => {
                 )
                 assert.fail('Expected function to throw')
             } catch (error) {
-                expect((error as Error).message).to.equal(
-                    'Authentication failed',
-                )
+                expect((error as Error).message).to.equal('Authentication failed')
                 sinon.assert.notCalled(mockOperation)
             }
         })


### PR DESCRIPTION
Implements essential test coverage for the DevCycle MCP server's API client infrastructure.

### What's Added
- **6 focused tests** for `DevCycleApiClient` class in `src/mcp/utils/api.test.ts`
- Covers critical user-facing functionality without over-testing edge cases

### Key Coverage Areas
- ✅ **Zodios error handling** - Ensures API schema mismatch recovery
- ✅ **Authentication workflows** - Validates auth requirements and error handling  
- ✅ **Dashboard link generation** - Tests core user workflow feature
- ✅ **Header management** - Verifies MCP tool tracking for telemetry