### PR TITLE
chore: adding worker-deploy action

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -30,7 +30,7 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             git diff --name-only HEAD^ HEAD > changed_files.txt
-            if grep -q "^mcp-worker/" changed_files.txt || grep -q "worker-deploy.yml" changed_files.txt; then
+            if grep -q "^mcp-worker/" changed_files.txt || grep -q "^src/mcp/" changed_files.txt || grep -q "worker-deploy.yml" changed_files.txt; then
               echo "changed=true" >> $GITHUB_OUTPUT
             else
               echo "changed=false" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -70,6 +70,3 @@ jobs:
           secrets: |
             AUTH0_CLIENT_ID
             AUTH0_CLIENT_SECRET
-        env:
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy MCP Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'mcp-worker/**'
+      - '.github/workflows/worker-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Workers
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for worker changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            git diff --name-only HEAD^ HEAD > changed_files.txt
+            if grep -q "^mcp-worker/" changed_files.txt || grep -q "worker-deploy.yml" changed_files.txt; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Skip deployment - no worker changes
+        if: steps.changes.outputs.changed == 'false'
+        run: echo "No changes detected in mcp-worker directory, skipping deployment"
+
+      - name: Enable Corepack
+        if: steps.changes.outputs.changed == 'true'
+        run: corepack enable
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.12
+          cache: 'yarn'
+
+      - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
+        run: yarn install
+
+      - name: Build worker
+        if: steps.changes.outputs.changed == 'true'
+        run: yarn build:worker
+
+      - name: Deploy to Cloudflare Workers
+        if: steps.changes.outputs.changed == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: mcp-worker
+          secrets: |
+            AUTH0_CLIENT_ID
+            AUTH0_CLIENT_SECRET
+        env:
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}


### PR DESCRIPTION
## feat: add Cloudflare Worker deployment workflow

Adds a new GitHub Actions workflow to automatically deploy the MCP Worker to Cloudflare Workers.

### Key Features
- **Smart deployment**: Only deploys when relevant files change (`mcp-worker/`, `src/mcp/`, or the workflow itself)
- **Manual trigger**: Supports `workflow_dispatch` for manual deployments  
- **Efficient builds**: Uses Yarn with caching and latest Node.js 22.x
- **Secure secrets**: Properly configured Auth0 credentials via Wrangler secrets injection

### Workflow Details
- Triggers on pushes to `main` branch with path filtering
- Checks for changes before proceeding with deployment
- Builds the worker using `yarn build:worker`
- Deploys to Cloudflare Workers using `wrangler-action@v3`
- Handles AUTH0 client credentials securely

This enables automatic deployment of the MCP Worker whenever the codebase is updated, ensuring the hosted service stays in sync with development.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat-mcp-server","parentHead":"205d1735f37c25ef76ee25eae0b40e28fa21362e","parentPull":467,"trunk":"main"}
```
-->
