### PR TITLE
fix: correct mcp tool operation names for dvc-referrer header

### DIFF
--- a/src/mcp/tools/featureTools.ts
+++ b/src/mcp/tools/featureTools.ts
@@ -288,7 +288,7 @@ export async function setFeatureTargetingHandler(
     const apiFunction = args.enabled ? enableTargeting : disableTargeting
 
     return await apiClient.executeWithDashboardLink(
-        operation,
+        'set_feature_targeting',
         args,
         async (authToken: string, projectKey: string | undefined) => {
             if (!projectKey) {
@@ -362,7 +362,7 @@ export async function updateFeatureTargetingHandler(
     const { feature_key, environment_key, ...configData } = args
 
     return await apiClient.executeWithDashboardLink(
-        'updateFeatureTargeting',
+        'update_feature_targeting',
         args,
         async (authToken: string, projectKey: string | undefined) => {
             if (!projectKey) {


### PR DESCRIPTION
## Fix MCP tool operation name consistency for dvc-referrer headers

### Problem
MCP tools had inconsistent operation names between tool registration and API client calls:
- `update_feature_targeting` tool: operation name was `'updateFeatureTargeting'` (camelCase) instead of `'update_feature_targeting'` (snake_case)
- `set_feature_targeting` tool: operation name was dynamic (`'enableTargeting'`/`'disableTargeting'`) instead of `'set_feature_targeting'`

This caused the `dvc-referrer-metadata` header to contain different command values than the registered tool names.

### Solution
- Fixed `update_feature_targeting`: Changed operation name from `'updateFeatureTargeting'` to `'update_feature_targeting'`
- Fixed `set_feature_targeting`: Changed operation name from dynamic `operation` variable to `'set_feature_targeting'`

### Impact
- ✅ Consistent snake_case naming convention across all MCP tools
- ✅ `dvc-referrer-metadata` headers now accurately reflect the actual tool being called
- ✅ Better API request tracking and analytics alignment

**Note**: This change addresses a header inconsistency that was identified while investigating "Internal server error" issues with the `update_feature_targeting` tool. Further testing may be needed to confirm if this resolves the underlying API error.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
