### PR TITLE
feat: add cleanup_feature tool and shared GitHub fetcher

### DIFF
--- a/src/mcp/tools/featureTools.ts
+++ b/src/mcp/tools/featureTools.ts
@@ -37,6 +37,8 @@ import { IDevCycleApiClient } from '../api/interface'
 import { DevCycleMCPServerInstance } from '../server'
 import { handleZodiosValidationErrors } from '../utils/api'
 import { dashboardLinks } from '../utils/dashboardLinks'
+import { fetchAiPromptsAndRules } from '../utils/github'
+import { CleanupFeatureArgsSchema } from '../types'
 
 // Individual handler functions
 export async function listFeaturesHandler(
@@ -675,6 +677,31 @@ export function registerFeatureTools(
             return await getFeatureAuditLogHistoryHandler(
                 validatedArgs,
                 apiClient,
+            )
+        },
+    )
+
+    // Cleanup Feature Prompt tool: fetches the cleanup prompt from GitHub
+    serverInstance.registerToolWithErrorHandling(
+        'cleanup_feature',
+        {
+            description: [
+                'Fetch the DevCycle Feature Cleanup prompt and return its markdown content.',
+                'Use this to guide safe cleanup of a completed feature and its variables in codebases.',
+                'Includes steps to analyze production state, complete the feature, and remove variables.',
+            ].join('\n'),
+            annotations: {
+                title: 'Cleanup Feature Prompt',
+                readOnlyHint: true,
+            },
+            inputSchema: CleanupFeatureArgsSchema.shape,
+        },
+        async (args: unknown) => {
+            // validate args
+            CleanupFeatureArgsSchema.parse(args)
+            return await fetchAiPromptsAndRules(
+                'clean-up-prompts/clean-up.md',
+                'Cleanup prompt not found at clean-up-prompts/clean-up.md.',
             )
         },
     )

--- a/src/mcp/tools/installTools.ts
+++ b/src/mcp/tools/installTools.ts
@@ -1,8 +1,7 @@
-import axios from 'axios'
 import { z } from 'zod'
-import type { IDevCycleApiClient } from '../api/interface'
 import type { DevCycleMCPServerInstance } from '../server'
 import { INSTALL_GUIDES } from './installGuides.generated'
+import { fetchAiPromptsAndRules } from '../utils/github'
 
 const InstallGuideArgsSchema = z.object({
     guide: z.enum(INSTALL_GUIDES),
@@ -16,26 +15,10 @@ async function fetchInstallGuideHandler(args: InstallGuideArgs) {
         ? trimmedGuide
         : `${trimmedGuide}.md`
     const repoPath = `install-prompts/${fileName}`
-    const sourceUrl = `https://raw.githubusercontent.com/DevCycleHQ/AI-Prompts-And-Rules/main/${repoPath}`
-
-    try {
-        const response = await axios.get<string>(sourceUrl, {
-            responseType: 'text',
-        })
-        return response.data as string
-    } catch (error: unknown) {
-        const status = axios.isAxiosError(error)
-            ? error.response?.status
-            : undefined
-        if (status === 404) {
-            throw new Error(
-                `Install guide "${fileName}" not found in install-prompts/. Check the filename (with or without .md).`,
-            )
-        }
-        throw new Error(
-            'Unable to fetch install guide from GitHub. Please retry.',
-        )
-    }
+    return await fetchAiPromptsAndRules(
+        repoPath,
+        `Install guide "${fileName}" not found in install-prompts/. Check the filename (with or without .md).`,
+    )
 }
 
 export function registerInstallTools(

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -468,6 +468,11 @@ export const GetFeatureAuditLogHistoryArgsSchema = z.object({
         .describe('Action type to filter audit entries by'),
 })
 
+// Cleanup feature prompt tool args
+export const CleanupFeatureArgsSchema = z.object({
+    featureKey: z.string(),
+})
+
 // Zod schema for DevCycle Audit Log Entity - matches the actual swagger specification
 export const AuditLogEntitySchema = z.object({
     date: z

--- a/src/mcp/utils/github.ts
+++ b/src/mcp/utils/github.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+
+export async function fetchAiPromptsAndRules(
+    relativePath: string,
+    notFoundMessage?: string,
+): Promise<string> {
+    const trimmedPath = relativePath.trim().replace(/^\/+|\/+$/g, '')
+    const sourceUrl = `https://raw.githubusercontent.com/DevCycleHQ/AI-Prompts-And-Rules/main/${trimmedPath}`
+
+    try {
+        const response = await axios.get<string>(sourceUrl, {
+            responseType: 'text',
+        })
+        return response.data as string
+    } catch (error: unknown) {
+        const status = axios.isAxiosError(error)
+            ? error.response?.status
+            : undefined
+        if (status === 404) {
+            throw new Error(
+                notFoundMessage ||
+                    `Resource not found in AI-Prompts-And-Rules: "${trimmedPath}"`,
+            )
+        }
+        throw new Error('Unable to fetch resource from GitHub. Please retry.')
+    }
+}


### PR DESCRIPTION
## Summary
- Added `cleanup_feature` MCP tool in `src/mcp/tools/featureTools.ts` to fetch the DevCycle Feature Cleanup prompt.
- Introduced shared GitHub fetcher `src/mcp/utils/github.ts` and refactored `installTools.ts` to use it.
- Added `CleanupFeatureArgsSchema` with `featureKey` to `src/mcp/types.ts`.

## Details
- Tool returns the cleanup prompt from the DevCycle prompts repo: [Cleanup prompt](https://raw.githubusercontent.com/DevCycleHQ/AI-Prompts-And-Rules/refs/heads/main/clean-up-prompts/clean-up.md).
- Schema aligns with existing MCP patterns and uses `featureKey` for context.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
