### PR TITLE
fix: update hono and validator to patched versions

### DIFF
--- a/mcp-worker/package.json
+++ b/mcp-worker/package.json
@@ -17,7 +17,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.13",
         "ably": "^1.2.48",
         "agents": "^0.2.19",
-        "hono": "^4.9.8",
+        "hono": "^4.10.3",
         "jose": "^6.1.0",
         "oauth4webapi": "^3.8.1"
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "axios": "^1.10.0",
         "chalk": "^4.1.2",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.1",
+        "class-validator": "^0.14.2",
         "estraverse": "^5.3.0",
         "fuzzy": "^0.1.3",
         "inquirer": "^8.2.6",
@@ -168,6 +168,7 @@
         "tmp": "0.2.5",
         "@types/estree": "1.0.5",
         "estraverse": "5.3.0",
-        "fast-json-patch": "3.1.1"
+        "fast-json-patch": "3.1.1",
+        "validator": "^13.15.20"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,7 +610,7 @@ __metadata:
     axios: "npm:^1.10.0"
     chalk: "npm:^4.1.2"
     class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.1"
+    class-validator: "npm:^0.14.2"
     eslint: "npm:^9.18.0"
     eslint-config-prettier: "npm:^9.1.0"
     estraverse: "npm:^5.3.0"
@@ -651,7 +651,7 @@ __metadata:
     "@types/node": "npm:^24.5.2"
     ably: "npm:^1.2.48"
     agents: "npm:^0.2.19"
-    hono: "npm:^4.9.8"
+    hono: "npm:^4.10.3"
     jose: "npm:^6.1.0"
     oauth4webapi: "npm:^3.8.1"
     vitest: "npm:^3.2.4"
@@ -3759,14 +3759,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-validator@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "class-validator@npm:0.14.1"
+"class-validator@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "class-validator@npm:0.14.2"
   dependencies:
     "@types/validator": "npm:^13.11.8"
-    libphonenumber-js: "npm:^1.10.53"
+    libphonenumber-js: "npm:^1.11.1"
     validator: "npm:^13.9.0"
-  checksum: 10c0/946e914e47548b5081449c720ea6a4877bac63dc960e14fca4b990b56e64efe3802d12f07ec22d6420c290245b72ea2d646939239f2a3b597794e6c4c2a4f2ae
+  checksum: 10c0/5bb67389d38fa23d342dffdd8e2dcee8235e1906e59799df5b2050278a6d89292fcaa88167f0215e3ddd684f47dcd51b004efa7be32d8aded91ee06cb317b3b8
   languageName: node
   linkType: hard
 
@@ -5761,10 +5761,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.9.8":
-  version: 4.10.2
-  resolution: "hono@npm:4.10.2"
-  checksum: 10c0/783ec7f879c8a0a389b65a92e43e15a3d60e9e67da749b88a84e763d4625c22493461d4c2c6c40068c554e27abfcf94db06a861ce94f871dd7ada2c751ad7a3b
+"hono@npm:^4.10.3":
+  version: 4.10.4
+  resolution: "hono@npm:4.10.4"
+  checksum: 10c0/90ce8dfacb70558f7549b5ee9bf4e5b4b29f76cb8be4d43a28ea0001458689bd63f51a2b1cae3f6ab05f7a50ce5442cb71c483c69dc7e986dd9217a5339c1fca
   languageName: node
   linkType: hard
 
@@ -6606,10 +6606,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libphonenumber-js@npm:^1.10.53":
-  version: 1.10.59
-  resolution: "libphonenumber-js@npm:1.10.59"
-  checksum: 10c0/68a2a13caedf304f3644ffd97faa308d74ae79d181b164d1a43d8f6c63643aa8e13117a3e2e53ea0dcaa16378121d2b6331d1b0353263d3ea7ca22f2bf3d1460
+"libphonenumber-js@npm:^1.11.1":
+  version: 1.12.25
+  resolution: "libphonenumber-js@npm:1.12.25"
+  checksum: 10c0/071c942e34e32d7883fb08a3c6f53003eca7067d06d19511c8ba7312fefe5420b998479afd078a5be6958bac163481072ba2560b4ccb5c680b7c6aa67b6810c2
   languageName: node
   linkType: hard
 
@@ -10303,10 +10303,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:^13.9.0":
-  version: 13.11.0
-  resolution: "validator@npm:13.11.0"
-  checksum: 10c0/0107da3add5a4ebc6391dac103c55f6d8ed055bbcc29a4c9cbf89eacfc39ba102a5618c470bdc33c6487d30847771a892134a8c791f06ef0962dd4b7a60ae0f5
+"validator@npm:^13.15.20":
+  version: 13.15.20
+  resolution: "validator@npm:13.15.20"
+  checksum: 10c0/65453f0c91ef154ae2da4d5ff3c22acff239d2c15216335ba83895b6f79914708709c641119aa9fba0ec9dd69229c1cf8196aff0081584bdda8a7f50ea97b789
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates vulnerable dependencies to patched versions:

- hono: 4.9.8 → 4.10.4
- class-validator: 0.14.1 → 0.14.2  
- validator: Added resolution to force ^13.15.20 (patched version)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
