### PR TITLE
chore: pin axios to 1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/validator": "^13.12.2",
         "@zodios/core": "^10.9.6",
-        "axios": "~1.13.6",
+        "axios": "1.13.6",
         "chalk": "^4.1.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@ __metadata:
     ajv: "npm:^8.18.0"
     ajv-cli: "npm:^5.0.0"
     ajv-formats: "npm:^3.0.1"
-    axios: "npm:~1.13.6"
+    axios: "npm:1.13.6"
     chalk: "npm:^4.1.2"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.2"
@@ -3127,7 +3127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.6, axios@npm:~1.13.6":
+"axios@npm:1.13.6":
   version: 1.13.6
   resolution: "axios@npm:1.13.6"
   dependencies:


### PR DESCRIPTION
## Summary

- Pins axios from `^1.13.6` to `1.13.6`
- Avoids exposure to the supply chain attack reported in axios 1.14.1