### PR TITLE
chore: bump axios to 1.15.0 to resolve dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/validator": "^13.12.2",
         "@zodios/core": "^10.9.6",
-        "axios": "1.13.6",
+        "axios": "1.15.0",
         "chalk": "^4.1.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -163,8 +163,8 @@
         "mcp-worker"
     ],
     "resolutions": {
-        "axios@npm:^1.13.6": "1.13.6",
-        "axios@npm:^1.6.0": "1.13.6",
+        "axios@npm:^1.13.6": "1.15.0",
+        "axios@npm:^1.6.0": "1.15.0",
         "nanoid@3.3.1": "3.3.8",
         "serialize-javascript@6.0.0": "^6.0.2",
         "tmp": "0.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@ __metadata:
     ajv: "npm:^8.18.0"
     ajv-cli: "npm:^5.0.0"
     ajv-formats: "npm:^3.0.1"
-    axios: "npm:1.13.6"
+    axios: "npm:1.15.0"
     chalk: "npm:^4.1.2"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.2"
@@ -3127,14 +3127,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.6":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -8105,10 +8105,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `axios` from `1.13.6` to `1.15.0` and updates resolutions to match
- Fixes alerts 191 (NO_PROXY hostname normalization bypass / SSRF) and 193 (header injection chain / cloud metadata exfiltration, CVSS 10)
- `1.15.0` is confirmed clean — it's the release that addressed the `1.14.x` supply chain issue we previously avoided