### PR TITLE
feat: add repository_dispatch to update CLI version on GitHub Action repos

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -135,6 +135,24 @@ jobs:
           latest_tag: $LATEST_TAG
           access_token: ${{ secrets.AUTOMATION_USER_TOKEN }}
 
+      - name: Update GitHub Actions
+        if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
+        with:
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          repository: DevCycleHQ/feature-flag-pr-insights-action
+          event-type: update-cli-version
+          client-payload: '{"version": "${{ env.LATEST_TAG }}"}'
+
+      - name: Update GitHub Actions (Code Usages)
+        if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
+        with:
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          repository: DevCycleHQ/feature-flag-code-usage-action
+          event-type: update-cli-version
+          client-payload: '{"version": "${{ env.LATEST_TAG }}"}'
+
       # Move this to release action yml once it works the first time
       - name: Update Homebrew Formula
         uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Update server.json version (pre-commit)
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
+          jq --indent 4 --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
           mv server.json.tmp server.json
           git add server.json
 
@@ -108,7 +108,7 @@ jobs:
       - name: Sync server.json version to tag
         run: |
           VERSION=${LATEST_TAG#v}
-          jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
+          jq --indent 4 --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
           mv server.json.tmp server.json
 
       - name: Validate server.json schema

--- a/server.json
+++ b/server.json
@@ -1,21 +1,21 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.devcycle/mcp",
-  "description": "DevCycle MCP server for feature flag management",
-  "version": "6.3.1",
-  "repository": {
-    "url": "https://github.com/DevCycleHQ/cli",
-    "source": "github"
-  },
-  "websiteUrl": "https://docs.devcycle.com/cli-mcp/mcp-getting-started",
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://mcp.devcycle.com/mcp"
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "com.devcycle/mcp",
+    "description": "DevCycle MCP server for feature flag management",
+    "version": "6.3.1",
+    "repository": {
+        "url": "https://github.com/DevCycleHQ/cli",
+        "source": "github"
     },
-    {
-      "type": "sse",
-      "url": "https://mcp.devcycle.com/sse"
-    }
-  ]
+    "websiteUrl": "https://docs.devcycle.com/cli-mcp/mcp-getting-started",
+    "remotes": [
+        {
+            "type": "streamable-http",
+            "url": "https://mcp.devcycle.com/mcp"
+        },
+        {
+            "type": "sse",
+            "url": "https://mcp.devcycle.com/sse"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` events to the CLI release workflow that trigger CLI version updates on `feature-flag-pr-insights-action` and `feature-flag-code-usage-action`
- Gated on `minor` or `patch` releases, matching the existing vscode-extension update behavior
- Fixes `server.json` formatting and uses `jq --indent 4` in the release workflow to prevent future drift

The target repos will each have a receiver workflow that handles the update, rebuilds `dist/`, and opens a PR.