### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
         "@hono/node-server": "^1.19.13",
         "follow-redirects": "^1.16.0",
         "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0": "^7.3.2",
-        "lodash": "^4.18.1"
+        "lodash": "^4.18.1",
+        "postcss": "^8.5.10"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7967,14 +7967,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.6":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+"postcss@npm:^8.5.10":
+  version: 8.5.14
+  resolution: "postcss@npm:8.5.14"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `postcss` resolution to `^8.5.10` (resolves to 8.5.14) to address medium severity vulnerability (alert #199)