### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         "picomatch@npm:^2.3.1": "^2.3.2",
         "picomatch@npm:^4.0.2": "^4.0.4",
         "picomatch@npm:^4.0.3": "^4.0.4",
-        "hono": "^4.12.14",
+        "hono": "^4.12.16",
         "@hono/node-server": "^1.19.13",
         "follow-redirects": "^1.16.0",
         "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@types/js-yaml": "4.0.9",
         "@types/validator": "13.12.2",
         "@zodios/core": "10.9.6",
-        "axios": "1.15.0",
+        "axios": "^1.15.2",
         "chalk": "4.1.2",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.2",
@@ -164,8 +164,8 @@
         "mcp-worker"
     ],
     "resolutions": {
-        "axios@npm:^1.13.6": "1.15.0",
-        "axios@npm:^1.6.0": "1.15.0",
+        "axios@npm:^1.13.6": "^1.15.2",
+        "axios@npm:^1.6.0": "^1.15.2",
         "nanoid@3.3.1": "3.3.8",
         "serialize-javascript@6.0.0": "^6.0.2",
         "tmp": "0.2.5",
@@ -199,6 +199,7 @@
         "follow-redirects": "^1.16.0",
         "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0": "^7.3.2",
         "lodash": "^4.18.1",
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.10",
+        "ip-address@npm:10.1.0": "^10.1.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@ __metadata:
     ajv: "npm:^8.18.0"
     ajv-cli: "npm:^5.0.0"
     ajv-formats: "npm:^3.0.1"
-    axios: "npm:1.15.0"
+    axios: "npm:^1.15.2"
     chalk: "npm:4.1.2"
     class-transformer: "npm:0.5.1"
     class-validator: "npm:0.14.2"
@@ -3127,14 +3127,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.15.2":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
   languageName: node
   linkType: hard
 
@@ -5771,10 +5771,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.1.0":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,10 +5454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.14":
-  version: 4.12.14
-  resolution: "hono@npm:4.12.14"
-  checksum: 10c0/78de4c98a9a3da0f067e38dcc4bd27f0d82b45d146ac39f5ca688515ee482c0a2e704d2ac6c1ee91ad17596b7c52b3e4b9483acd9c238d42f6ebcb43414a71b6
+"hono@npm:^4.12.16":
+  version: 4.12.18
+  resolution: "hono@npm:4.12.18"
+  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolved 14 open Dependabot security alerts.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #200-#212 | `axios` | **high/medium/low** | Resolutions bumped from `1.15.0` → `^1.15.2` (resolves to 1.16.0) |
| #213 | `ip-address` | **medium** | Override `10.1.0` → `^10.1.1` (resolves to 10.2.0) |