### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/mcp-worker/package.json
+++ b/mcp-worker/package.json
@@ -17,7 +17,7 @@
         "@cloudflare/workers-oauth-provider": "^0.3.0",
         "ably": "^2.19.0",
         "agents": "^0.7.6",
-        "hono": "4.12.14",
+        "hono": "^4.12.18",
         "jose": "^6.2.1",
         "oauth4webapi": "^3.8.5"
     },

--- a/package.json
+++ b/package.json
@@ -194,12 +194,13 @@
         "picomatch@npm:^2.3.1": "^2.3.2",
         "picomatch@npm:^4.0.2": "^4.0.4",
         "picomatch@npm:^4.0.3": "^4.0.4",
-        "hono": "^4.12.16",
+        "hono": "^4.12.18",
         "@hono/node-server": "^1.19.13",
         "follow-redirects": "^1.16.0",
         "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0": "^7.3.2",
         "lodash": "^4.18.1",
         "postcss": "^8.5.10",
-        "ip-address@npm:10.1.0": "^10.1.1"
+        "ip-address@npm:10.1.0": "^10.1.1",
+        "fast-uri@npm:^3.0.1": "^3.1.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,7 +432,7 @@ __metadata:
     "@types/node": "npm:^25.4.0"
     ably: "npm:^2.19.0"
     agents: "npm:^0.7.6"
-    hono: "npm:4.12.14"
+    hono: "npm:^4.12.18"
     jose: "npm:^6.2.1"
     oauth4webapi: "npm:^3.8.5"
     vitest: "npm:^3.2.4"
@@ -4838,10 +4838,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+"fast-uri@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -5454,10 +5454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.16":
-  version: 4.12.18
-  resolution: "hono@npm:4.12.18"
-  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
+"hono@npm:^4.12.18":
+  version: 4.12.21
+  resolution: "hono@npm:4.12.21"
+  checksum: 10c0/2d26049eadc7dc879f7a442e127bea5c896b029050dc9fb81c950c190d5bd15da66a161b5132331451584d6a596a59162200f8840e796ddb9ae34a0e358e48a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 7 open Dependabot security alerts by bumping vulnerable dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #232 | `hono` | **medium** | Bumped resolution to ^4.12.18 (resolves to 4.12.21) |
| #230 | `hono` | **low** | Bumped resolution to ^4.12.18 (resolves to 4.12.21) |
| #228 | `hono` | **medium** | Bumped resolution to ^4.12.18 (resolves to 4.12.21) |
| #227 | `fast-uri` | **high** | Added resolution ^3.1.2 (resolves to 3.1.2) |
| #226 | `fast-uri` | **high** | Added resolution ^3.1.2 (resolves to 3.1.2) |
| #224 | `hono` | **medium** | Bumped resolution to ^4.12.18 (resolves to 4.12.21) |
| #222 | `hono` | **medium** | Bumped resolution to ^4.12.18 (resolves to 4.12.21) |

Alert #213 (ip-address) was already resolved in a prior merged PR.

## Notes

- `hono` is a direct dependency in `mcp-worker/package.json`; bumped to `^4.12.18` there as well
- `fast-uri` is a transitive dependency via `ajv`; resolved via yarn resolutions