### PR TITLE
chore: reduce dependency resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
         "axios@npm:^1.13.6": "^1.15.2",
         "axios@npm:^1.6.0": "^1.15.2",
         "tmp": "0.2.5",
-        "@types/estree": "1.0.9",
+        "@types/estree": "1.0.5",
         "estraverse": "5.3.0",
         "fast-json-patch": "3.1.1",
         "validator": "^13.15.20",

--- a/package.json
+++ b/package.json
@@ -166,10 +166,8 @@
     "resolutions": {
         "axios@npm:^1.13.6": "^1.15.2",
         "axios@npm:^1.6.0": "^1.15.2",
-        "nanoid@3.3.1": "3.3.8",
-        "serialize-javascript@6.0.0": "^6.0.2",
         "tmp": "0.2.5",
-        "@types/estree": "1.0.5",
+        "@types/estree": "1.0.9",
         "estraverse": "5.3.0",
         "fast-json-patch": "3.1.1",
         "validator": "^13.15.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2255,10 +2255,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.9":
-  version: 1.0.9
-  resolution: "@types/estree@npm:1.0.9"
-  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+"@types/estree@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@types/estree@npm:1.0.5"
+  checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2255,10 +2255,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.5":
-  version: 1.0.5
-  resolution: "@types/estree@npm:1.0.5"
-  checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
+"@types/estree@npm:1.0.9":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- reduces dependency `resolutions` where patched versions are now selected naturally
- bumps remaining resolution floors or same-major package ranges where needed
- updates `yarn.lock`

## Testing
- `yarn install --immutable`