### PR TITLE
Remove stale package types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "keywords": [
         "oclif"
     ],
-    "types": "dist/index.d.ts",
     "packageManager": "yarn@4.9.2",
     "workspaces": [
         "mcp-worker"


### PR DESCRIPTION
## Summary
- remove the stale 	ypes field from package.json
- avoid advertising dist/index.d.ts, which is not generated by the current TypeScript config and is not present in the published package tarball

## Validation
- Confirmed 
pm view @devcycle/cli@6.3.2 name version types main bin --json reports 	ypes: "dist/index.d.ts".
- Confirmed 
pm pack @devcycle/cli@6.3.2 --dry-run --json does not include dist/index.d.ts.
- Parsed the updated package.json with Node and verified the stale 	ypes field is absent.
- Ran git diff --check.

Related: charles-openclaw/charles-microbounties#1318