### PR TITLE
Remove unused registration endpoint.

### DIFF
--- a/mcp-worker/src/index.ts
+++ b/mcp-worker/src/index.ts
@@ -167,7 +167,6 @@ export default {
             defaultHandler: app,
             authorizeEndpoint: '/oauth/authorize',
             tokenEndpoint: '/oauth/token',
-            clientRegistrationEndpoint: '/oauth/register',
             tokenExchangeCallback: createTokenExchangeCallback(env),
         })
 


### PR DESCRIPTION
This endpoint can add confusion and misunderstanding since we don't actually support or use anything to do with client registration.