### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ mcp-worker/.wrangler/
 
 # MCP Worker environment variables
 .dev.vars
+
+# git worktrees
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@types/js-yaml": "4.0.9",
         "@types/validator": "13.12.2",
         "@zodios/core": "10.9.6",
-        "axios": "^1.15.2",
+        "axios": "^1.18.0",
         "chalk": "4.1.2",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.2",
@@ -61,7 +61,7 @@
         "inquirer": "8.2.6",
         "inquirer-autocomplete-prompt": "2.0.1",
         "js-sha256": "0.11.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "lodash": "4.18.1",
         "minimatch": "9.0.9",
         "open": "8.4.2",
@@ -164,8 +164,8 @@
         "mcp-worker"
     ],
     "resolutions": {
-        "axios@npm:^1.13.6": "^1.15.2",
-        "axios@npm:^1.6.0": "^1.15.2",
+        "axios@npm:^1.13.6": "^1.18.0",
+        "axios@npm:^1.6.0": "^1.18.0",
         "tmp": "^0.2.6",
         "shell-quote": "^1.8.4",
         "yeoman-environment": "^6.0.1",
@@ -190,9 +190,10 @@
         "handlebars@npm:^4.7.7": "^4.7.9",
         "path-to-regexp@npm:^8.0.0": "^8.4.0",
         "path-to-regexp@npm:^8.1.0": "^8.4.0",
-        "brace-expansion@npm:^1.1.7": "^1.1.13",
-        "brace-expansion@npm:^2.0.1": "^2.0.3",
-        "brace-expansion@npm:^2.0.2": "^2.0.3",
+        "brace-expansion@npm:^1.1.7": "^1.1.16",
+        "brace-expansion@npm:^2.0.1": "^2.1.2",
+        "brace-expansion@npm:^2.0.2": "^2.1.2",
+        "brace-expansion@npm:^5.0.5": "^5.0.7",
         "picomatch@npm:^2.3.1": "^2.3.2",
         "picomatch@npm:^4.0.2": "^4.0.4",
         "picomatch@npm:^4.0.3": "^4.0.4",
@@ -212,6 +213,8 @@
         "js-yaml@npm:^3.14.1": "^3.15.0",
         "@babel/core@npm:^7.20.12": "^7.29.6",
         "form-data@npm:^4.0.5": "^4.0.6",
-        "esbuild@npm:0.27.3": "^0.28.1"
+        "esbuild@npm:0.27.3": "^0.28.1",
+        "body-parser@npm:^2.2.1": "^2.3.0",
+        "js-yaml@npm:^4.1.0": "^4.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "inquirer": "8.2.6",
         "inquirer-autocomplete-prompt": "2.0.1",
         "js-sha256": "0.11.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "^4.2.0",
         "lodash": "4.18.1",
         "minimatch": "9.0.9",
         "open": "8.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,7 +470,7 @@ __metadata:
     ajv: "npm:^8.18.0"
     ajv-cli: "npm:^5.0.0"
     ajv-formats: "npm:^3.0.1"
-    axios: "npm:^1.15.2"
+    axios: "npm:^1.18.0"
     chalk: "npm:4.1.2"
     class-transformer: "npm:0.5.1"
     class-validator: "npm:0.14.2"
@@ -482,7 +482,7 @@ __metadata:
     inquirer: "npm:8.2.6"
     inquirer-autocomplete-prompt: "npm:2.0.1"
     js-sha256: "npm:0.11.0"
-    js-yaml: "npm:4.1.1"
+    js-yaml: "npm:4.2.0"
     lodash: "npm:4.18.1"
     minimatch: "npm:9.0.9"
     nock: "npm:^13.5.6"
@@ -3524,14 +3524,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.2":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
+"axios@npm:^1.18.0":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
+  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
   languageName: node
   linkType: hard
 
@@ -3648,20 +3649,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^2.2.1":
-  version: 2.2.2
-  resolution: "body-parser@npm:2.2.2"
+"body-parser@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "body-parser@npm:2.3.0"
   dependencies:
     bytes: "npm:^3.1.2"
-    content-type: "npm:^1.0.5"
+    content-type: "npm:^2.0.0"
     debug: "npm:^4.4.3"
-    http-errors: "npm:^2.0.0"
-    iconv-lite: "npm:^0.7.0"
+    http-errors: "npm:^2.0.1"
+    iconv-lite: "npm:^0.7.2"
     on-finished: "npm:^2.4.1"
-    qs: "npm:^6.14.1"
-    raw-body: "npm:^3.0.1"
-    type-is: "npm:^2.0.1"
-  checksum: 10c0/95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
+    qs: "npm:^6.15.2"
+    raw-body: "npm:^3.0.2"
+    type-is: "npm:^2.1.0"
+  checksum: 10c0/2a8fbbdc471b588338555a3e1a597d1eb0ad0c21cf20fdc3bac5d3f8d9c3a4b19b4163575ab852a43a5dfc0df7770ced5284f979e561f1a24c2f851ce89e695a
   languageName: node
   linkType: hard
 
@@ -3675,31 +3676,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.13":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
+"brace-expansion@npm:^1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "brace-expansion@npm:2.1.0"
+"brace-expansion@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 
@@ -4263,6 +4264,13 @@ __metadata:
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "content-type@npm:2.0.0"
+  checksum: 10c0/491539fff707d7594b0ca4fabcc084bef2a31ffa754ff0a4f80c4377e3963cff0394317f9271c24087596c97fa675bc123d61fa34ffe65b4904e7d3d3098de72
   languageName: node
   linkType: hard
 
@@ -5972,7 +5980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:^2.0.0, http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -6016,7 +6024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
+"https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -6084,21 +6092,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
-  version: 0.7.0
-  resolution: "iconv-lite@npm:0.7.0"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/2382400469071c55b6746c531eed5fa4d033e5db6690b7331fb2a5f59a30d7a9782932e92253db26df33c1cf46fa200a3fbe524a2a7c62037c762283f188ec2f
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.7.2":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:~0.7.0":
+  version: 0.7.0
+  resolution: "iconv-lite@npm:0.7.0"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/2382400469071c55b6746c531eed5fa4d033e5db6690b7331fb2a5f59a30d7a9782932e92253db26df33c1cf46fa200a3fbe524a2a7c62037c762283f188ec2f
   languageName: node
   linkType: hard
 
@@ -6597,14 +6605,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1, js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 
@@ -6617,6 +6625,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -8960,7 +8979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.2":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -10420,6 +10439,17 @@ __metadata:
     media-typer: "npm:^1.1.0"
     mime-types: "npm:^3.0.0"
   checksum: 10c0/7f7ec0a060b16880bdad36824ab37c26019454b67d73e8a465ed5a3587440fbe158bc765f0da68344498235c877e7dbbb1600beccc94628ed05599d667951b99
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "type-is@npm:2.1.0"
+  dependencies:
+    content-type: "npm:^2.0.0"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/a6018f8f509de48f2c7429305e3a920e73b374fa93127dd0877ae1c2df65a5d33907caac8afb0c37a9b9fc7c49f29e3f55d668963dc845d966930b667c07f50e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,7 +482,7 @@ __metadata:
     inquirer: "npm:8.2.6"
     inquirer-autocomplete-prompt: "npm:2.0.1"
     js-sha256: "npm:0.11.0"
-    js-yaml: "npm:4.2.0"
+    js-yaml: "npm:^4.2.0"
     lodash: "npm:4.18.1"
     minimatch: "npm:9.0.9"
     nock: "npm:^13.5.6"
@@ -6602,17 +6602,6 @@ __metadata:
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `axios` from `^1.15.2` to `^1.18.0` to resolve 6 CVEs (alerts #265-#269, #272; medium/high severity)
- Changed `js-yaml` from exact pin `4.1.1` to range `^4.2.0` and added a `^4.1.0` resolution mapping to `^4.2.0` to cover transitive consumers (alert #264; medium) — both now resolve to a single 4.3.0 instance
- Added `brace-expansion@npm:^5.0.5` resolution `^5.0.7` to fix the 5.x vulnerable range (alert #270; high — DoS via exponential-time expansion)
- Added `body-parser@npm:^2.2.1` resolution `^2.3.0` to fix transitive dep via `express` (alert #271; low)
- Alert #263 (`sigstore` high) is not resolved: the vulnerable `sigstore@1.9.0` is a transitive devDep (oclif -> yeoman-generator -> pacote@15.2.0 -> sigstore@^1.3.0) and no patched 1.x version exists; the only fix would be a major-version bump to 4.x which breaks pacote@15.2.0