### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -40,7 +40,7 @@ runs:
         release-tag: ${{ env.LATEST_TAG }}
         
     - name: Set up Node.js for npm publish
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         registry-url: "https://registry.npmjs.org"
         scope: "@devcycle"

--- a/.github/actions/update-doc/action.yml
+++ b/.github/actions/update-doc/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: DevCycleHQ/devcycle-docs
         path: devcycle-docs

--- a/.github/actions/update-vscode-extension/action.yml
+++ b/.github/actions/update-vscode-extension/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         repository: DevCycleHQ/vscode-extension
         path: vscode-extension

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Update GitHub Actions
         if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/feature-flag-pr-insights-action
@@ -146,7 +146,7 @@ jobs:
 
       - name: Update GitHub Actions (Code Usages)
         if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/feature-flag-code-usage-action
@@ -155,7 +155,7 @@ jobs:
 
       # Move this to release action yml once it works the first time
       - name: Update Homebrew Formula
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/homebrew-cli

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       - run: corepack enable
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "${{ steps.get_node_version.outputs.NVMRC }}"
           registry-url: "https://registry.npmjs.org"
@@ -137,7 +137,7 @@ jobs:
 
       - name: Update GitHub Actions
         if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/feature-flag-pr-insights-action
@@ -146,7 +146,7 @@ jobs:
 
       - name: Update GitHub Actions (Code Usages)
         if: inputs.npm-version == 'minor' || inputs.npm-version == 'patch'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/feature-flag-code-usage-action
@@ -155,7 +155,7 @@ jobs:
 
       # Move this to release action yml once it works the first time
       - name: Update Homebrew Formula
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           repository: DevCycleHQ/homebrew-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: DevCycleHQ/license-action@main
         with:
           language: "javascript"
@@ -22,12 +22,12 @@ jobs:
       matrix:
           node-version: [22.12]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - run: corepack enable
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.